### PR TITLE
Add history tracking for TTS requests

### DIFF
--- a/Sources/Tyler/Audio/TTSService.swift
+++ b/Sources/Tyler/Audio/TTSService.swift
@@ -5,12 +5,23 @@ enum TTSVoice: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 }
 
+struct TTSResult {
+    let audioData: Data
+    let inputTokens: Int
+    let isTokenEstimated: Bool  // true if tokens were estimated, false if from API
+}
+
 final class TTSService: NSObject {
     private var currentTask: URLSessionDataTask?
     private var session: URLSession?
     private var onAudioChunk: ((Data) -> Void)?
-    private var onComplete: (() -> Void)?
+    private var onComplete: ((TTSResult) -> Void)?
     private var onError: ((Error) -> Void)?
+    private var accumulatedAudioData = Data()
+    private var inputTokens: Int = 0
+    private var isTokenEstimated: Bool = false
+    private var responseHeaders: [AnyHashable: Any] = [:]
+    private var inputText: String = ""
 
     func streamSpeech(
         text: String,
@@ -18,11 +29,18 @@ final class TTSService: NSObject {
         apiKey: String,
         instructions: String = "Speak naturally and clearly.",
         onAudioChunk: @escaping (Data) -> Void,
-        onComplete: @escaping () -> Void,
+        onComplete: @escaping (TTSResult) -> Void,
         onError: @escaping (Error) -> Void
     ) {
         print("[Tyler] TTSService.streamSpeech called")
         print("[Tyler] Text length: \(text.count), voice: \(voice.rawValue)")
+
+        // Reset accumulated data for new request
+        accumulatedAudioData = Data()
+        inputTokens = 0
+        isTokenEstimated = false
+        responseHeaders = [:]
+        inputText = text
 
         self.onAudioChunk = onAudioChunk
         self.onComplete = onComplete
@@ -80,6 +98,7 @@ final class TTSService: NSObject {
 extension TTSService: URLSessionDataDelegate {
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         print("[Tyler] 📦 Received data chunk: \(data.count) bytes")
+        accumulatedAudioData.append(data)
         onAudioChunk?(data)
     }
 
@@ -88,19 +107,91 @@ extension TTSService: URLSessionDataDelegate {
             // Check if it's a cancellation
             if (error as NSError).code == NSURLErrorCancelled {
                 print("[Tyler] Request cancelled")
+                accumulatedAudioData = Data()
+                inputTokens = 0
+                isTokenEstimated = false
+                inputText = ""
                 return
             }
             print("[Tyler] ❌ Network error: \(error.localizedDescription)")
+            accumulatedAudioData = Data()
+            inputTokens = 0
+            isTokenEstimated = false
+            inputText = ""
             onError?(error)
         } else {
-            print("[Tyler] ✅ Request completed successfully")
-            onComplete?()
+            // Try to parse the response for usage info (fallback check)
+            parseResponseForUsage()
+            
+            // If we still don't have tokens from headers or body, estimate from input text
+            if inputTokens == 0 && !inputText.isEmpty {
+                // Rough estimation: ~4 characters per token for English text
+                // This is a common approximation for GPT tokenizers
+                inputTokens = max(1, inputText.count / 4)
+                isTokenEstimated = true
+                print("[Tyler] 📊 Estimated input tokens from text length: \(inputTokens) (from \(inputText.count) chars)")
+            }
+
+            print("[Tyler] ✅ Request completed successfully, total audio: \(accumulatedAudioData.count) bytes, inputTokens: \(inputTokens)\(isTokenEstimated ? " (estimated)" : "")")
+            let result = TTSResult(audioData: accumulatedAudioData, inputTokens: inputTokens, isTokenEstimated: isTokenEstimated)
+            accumulatedAudioData = Data()
+            inputTokens = 0
+            isTokenEstimated = false
+            inputText = ""
+            onComplete?(result)
+        }
+    }
+
+    private func parseResponseForUsage() {
+        // For TTS API, usage info comes from HTTP headers (extracted in extractUsageFromHeaders)
+        // The response body contains raw audio data, not JSON
+        // This method is kept for compatibility but usage is already extracted from headers
+        
+        // If we still don't have tokens, it means the header wasn't present
+        // Log for debugging purposes
+        if inputTokens == 0 {
+            print("[Tyler] ⚠️ Input tokens still 0 - checking if response body contains error JSON")
+            
+            // Only try to parse as JSON if it looks like an error response (not binary audio)
+            if let responseString = String(data: accumulatedAudioData, encoding: .utf8),
+               responseString.hasPrefix("{") {
+                let preview = String(responseString.prefix(500))
+                print("[Tyler] 📄 Response preview (possible error): \(preview)")
+                
+                if let json = try? JSONSerialization.jsonObject(with: accumulatedAudioData) as? [String: Any] {
+                    // Check for error response
+                    if let error = json["error"] as? [String: Any] {
+                        print("[Tyler] ❌ API returned error in body: \(error)")
+                    }
+                    // Check for usage in body (unlikely for TTS but just in case)
+                    if let usage = json["usage"] as? [String: Any],
+                       let tokens = usage["input_tokens"] as? Int {
+                        inputTokens = tokens
+                        print("[Tyler] 📊 Input tokens from response body: \(inputTokens)")
+                    }
+                }
+            }
         }
     }
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
         if let httpResponse = response as? HTTPURLResponse {
             print("[Tyler] 📡 HTTP response: \(httpResponse.statusCode)")
+            print("[Tyler] 📡 Content-Type: \(httpResponse.allHeaderFields["Content-Type"] ?? "unknown")")
+
+            // Store headers for later usage extraction
+            responseHeaders = httpResponse.allHeaderFields
+
+            // Log all headers for debugging
+            print("[Tyler] 📡 Response headers:")
+            for (key, value) in httpResponse.allHeaderFields {
+                print("[Tyler]   \(key): \(value)")
+            }
+
+            // Extract usage from headers if available
+            // OpenAI TTS returns usage in x-openai-* headers
+            extractUsageFromHeaders(httpResponse.allHeaderFields)
+
             if httpResponse.statusCode != 200 {
                 print("[Tyler] ❌ API error: HTTP \(httpResponse.statusCode)")
                 onError?(TTSError.apiError(statusCode: httpResponse.statusCode))
@@ -109,6 +200,49 @@ extension TTSService: URLSessionDataDelegate {
             }
         }
         completionHandler(.allow)
+    }
+
+    private func extractUsageFromHeaders(_ headers: [AnyHashable: Any]) {
+        // OpenAI returns usage info in various header formats
+        // Check for common patterns (case-insensitive lookup)
+        let headerDict = Dictionary(uniqueKeysWithValues: headers.map { 
+            (String(describing: $0.key).lowercased(), $0.value) 
+        })
+        
+        // Try different possible header names for input tokens USED in this request
+        // NOTE: Do NOT include rate limit headers like x-ratelimit-remaining-tokens
+        // as those show quota remaining, not tokens used
+        let possibleTokenHeaders = [
+            "x-openai-input-tokens",
+            "openai-input-tokens", 
+            "x-input-tokens",
+            "x-request-input-tokens",
+            "openai-processing-tokens"
+        ]
+        
+        for headerName in possibleTokenHeaders {
+            if let value = headerDict[headerName] {
+                if let intValue = value as? Int {
+                    inputTokens = intValue
+                    print("[Tyler] 📊 Input tokens from header '\(headerName)': \(inputTokens)")
+                    return
+                } else if let stringValue = value as? String, let intValue = Int(stringValue) {
+                    inputTokens = intValue
+                    print("[Tyler] 📊 Input tokens from header '\(headerName)': \(inputTokens)")
+                    return
+                }
+            }
+        }
+        
+        // Log available headers for debugging to help identify the correct one
+        print("[Tyler] ⚠️ No input token header found. Available headers with numeric values:")
+        for (key, value) in headerDict {
+            if let strVal = value as? String, Int(strVal) != nil {
+                print("[Tyler]   - \(key): \(strVal)")
+            } else if value is Int {
+                print("[Tyler]   - \(key): \(value)")
+            }
+        }
     }
 }
 

--- a/Sources/Tyler/Core/AppState.swift
+++ b/Sources/Tyler/Core/AppState.swift
@@ -104,8 +104,18 @@ final class AppState: ObservableObject {
                     self?.logger.debug("Received audio chunk: \(data.count) bytes", source: "AppState")
                     self?.audioPlayer.enqueue(pcmData: data)
                 },
-                onComplete: { [weak self] in
-                    self?.logger.info("TTS stream complete", source: "AppState")
+                onComplete: { [weak self] result in
+                    self?.logger.info("TTS stream complete, audio size: \(result.audioData.count) bytes, inputTokens: \(result.inputTokens)", source: "AppState")
+
+                    // Save to history
+                    HistoryManager.shared.addEntry(
+                        text: text,
+                        voice: voice.rawValue,
+                        inputTokens: result.inputTokens,
+                        audioData: result.audioData
+                    )
+                    self?.logger.info("Saved to history", source: "AppState")
+
                     Task { @MainActor in
                         // Small delay to let audio finish playing
                         try? await Task.sleep(nanoseconds: 500_000_000)

--- a/Sources/Tyler/Core/HistoryEntry.swift
+++ b/Sources/Tyler/Core/HistoryEntry.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+struct HistoryEntry: Identifiable, Codable {
+    let id: UUID
+    let timestamp: Date
+    let text: String
+    let voice: String
+    let inputTokens: Int
+    let cost: Double
+    let audioFileName: String
+
+    init(id: UUID = UUID(), timestamp: Date = Date(), text: String, voice: String, inputTokens: Int, audioFileName: String) {
+        self.id = id
+        self.timestamp = timestamp
+        self.text = text
+        self.voice = voice
+        self.inputTokens = inputTokens
+        self.cost = TTSPricing.calculateCost(inputTokens: inputTokens)
+        self.audioFileName = audioFileName
+    }
+
+    var formattedTimestamp: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .medium
+        return formatter.string(from: timestamp)
+    }
+
+    var formattedCost: String {
+        String(format: "$%.6f", cost)
+    }
+
+    var truncatedText: String {
+        if text.count > 100 {
+            return String(text.prefix(100)) + "..."
+        }
+        return text
+    }
+}
+
+enum TTSPricing {
+    // gpt-4o-mini-tts pricing: $0.60 per 1M input tokens
+    static let costPerMillionTokens: Double = 0.60
+
+    static func calculateCost(inputTokens: Int) -> Double {
+        return Double(inputTokens) / 1_000_000.0 * costPerMillionTokens
+    }
+}

--- a/Sources/Tyler/Core/HistoryManager.swift
+++ b/Sources/Tyler/Core/HistoryManager.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+@Observable
+final class HistoryManager {
+    static let shared = HistoryManager()
+
+    private(set) var entries: [HistoryEntry] = []
+
+    private let maxEntries = 100
+    private let maxDiskSpaceMB: Double = 500
+
+    private var appSupportDirectory: URL {
+        let paths = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+        return paths[0].appendingPathComponent("Tyler", isDirectory: true)
+    }
+
+    private var historyFile: URL {
+        appSupportDirectory.appendingPathComponent("history.json")
+    }
+
+    private var audioDirectory: URL {
+        appSupportDirectory.appendingPathComponent("audio", isDirectory: true)
+    }
+
+    private init() {
+        ensureDirectoriesExist()
+        loadHistory()
+    }
+
+    // MARK: - Public API
+
+    @discardableResult
+    func addEntry(text: String, voice: String, inputTokens: Int, audioData: Data) -> HistoryEntry {
+        let audioFileName = "\(UUID().uuidString).pcm"
+        let audioURL = audioDirectory.appendingPathComponent(audioFileName)
+
+        // Save audio file
+        do {
+            try audioData.write(to: audioURL)
+        } catch {
+            print("[Tyler] Failed to save audio file: \(error)")
+        }
+
+        let entry = HistoryEntry(
+            text: text,
+            voice: voice,
+            inputTokens: inputTokens,
+            audioFileName: audioFileName
+        )
+
+        DispatchQueue.main.async {
+            self.entries.insert(entry, at: 0)
+            self.saveHistory()
+            self.enforceRetentionPolicy()
+        }
+
+        return entry
+    }
+
+    func deleteEntry(_ entry: HistoryEntry) {
+        // Delete audio file
+        let audioURL = audioDirectory.appendingPathComponent(entry.audioFileName)
+        try? FileManager.default.removeItem(at: audioURL)
+
+        DispatchQueue.main.async {
+            self.entries.removeAll { $0.id == entry.id }
+            self.saveHistory()
+        }
+    }
+
+    func clearAllHistory() {
+        // Delete all audio files
+        for entry in entries {
+            let audioURL = audioDirectory.appendingPathComponent(entry.audioFileName)
+            try? FileManager.default.removeItem(at: audioURL)
+        }
+
+        DispatchQueue.main.async {
+            self.entries.removeAll()
+            self.saveHistory()
+        }
+    }
+
+    func getAudioData(for entry: HistoryEntry) -> Data? {
+        let audioURL = audioDirectory.appendingPathComponent(entry.audioFileName)
+        return try? Data(contentsOf: audioURL)
+    }
+
+    // MARK: - Private Methods
+
+    private func ensureDirectoriesExist() {
+        let fileManager = FileManager.default
+
+        if !fileManager.fileExists(atPath: appSupportDirectory.path) {
+            try? fileManager.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        }
+
+        if !fileManager.fileExists(atPath: audioDirectory.path) {
+            try? fileManager.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+        }
+    }
+
+    private func saveHistory() {
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try encoder.encode(entries)
+            try data.write(to: historyFile)
+        } catch {
+            print("[Tyler] Failed to save history: \(error)")
+        }
+    }
+
+    private func loadHistory() {
+        guard FileManager.default.fileExists(atPath: historyFile.path) else { return }
+
+        do {
+            let data = try Data(contentsOf: historyFile)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            entries = try decoder.decode([HistoryEntry].self, from: data)
+        } catch {
+            print("[Tyler] Failed to load history: \(error)")
+        }
+    }
+
+    private func enforceRetentionPolicy() {
+        // Enforce max entries
+        while entries.count > maxEntries {
+            if let lastEntry = entries.last {
+                deleteEntry(lastEntry)
+            }
+        }
+
+        // Enforce max disk space
+        var totalSize = calculateTotalDiskUsage()
+        let maxBytes = Int64(maxDiskSpaceMB * 1024 * 1024)
+
+        while totalSize > maxBytes && !entries.isEmpty {
+            if let lastEntry = entries.last {
+                deleteEntry(lastEntry)
+                totalSize = calculateTotalDiskUsage()
+            }
+        }
+    }
+
+    private func calculateTotalDiskUsage() -> Int64 {
+        var totalSize: Int64 = 0
+        let fileManager = FileManager.default
+
+        for entry in entries {
+            let audioURL = audioDirectory.appendingPathComponent(entry.audioFileName)
+            if let attributes = try? fileManager.attributesOfItem(atPath: audioURL.path),
+               let size = attributes[.size] as? Int64 {
+                totalSize += size
+            }
+        }
+
+        return totalSize
+    }
+
+    var totalCost: Double {
+        entries.reduce(0) { $0 + $1.cost }
+    }
+
+    var formattedTotalCost: String {
+        String(format: "$%.6f", totalCost)
+    }
+}

--- a/Sources/Tyler/Views/HistoryTableView.swift
+++ b/Sources/Tyler/Views/HistoryTableView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct HistoryTableView: View {
+    let entries: [HistoryEntry]
+    @Binding var playingEntryId: UUID?
+    let onReplay: (HistoryEntry) -> Void
+    let onDelete: (HistoryEntry) -> Void
+
+    var body: some View {
+        Table(entries) {
+            TableColumn("Time") { entry in
+                Text(entry.formattedTimestamp)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundColor(.secondary)
+            }
+            .width(min: 120, ideal: 140)
+
+            TableColumn("Text") { entry in
+                Text(entry.truncatedText)
+                    .font(.system(.caption))
+                    .lineLimit(2)
+                    .help(entry.text)
+            }
+            .width(min: 200, ideal: 300)
+
+            TableColumn("Voice") { entry in
+                Text(entry.voice.capitalized)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .width(60)
+
+            TableColumn("Cost") { entry in
+                Text(entry.formattedCost)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundColor(.secondary)
+            }
+            .width(60)
+
+            TableColumn("Actions") { entry in
+                HStack(spacing: 8) {
+                    Button {
+                        onReplay(entry)
+                    } label: {
+                        Image(systemName: playingEntryId == entry.id ? "stop.fill" : "play.fill")
+                            .foregroundColor(playingEntryId == entry.id ? .red : .accentColor)
+                    }
+                    .buttonStyle(.borderless)
+                    .help(playingEntryId == entry.id ? "Stop" : "Replay")
+
+                    Button {
+                        onDelete(entry)
+                    } label: {
+                        Image(systemName: "trash")
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Delete")
+                }
+            }
+            .width(80)
+        }
+        .tableStyle(.inset(alternatesRowBackgrounds: true))
+    }
+}

--- a/Sources/Tyler/Views/HistoryView.swift
+++ b/Sources/Tyler/Views/HistoryView.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+
+struct HistoryView: View {
+    @State private var historyManager = HistoryManager.shared
+    @State private var playingEntryId: UUID?
+    private let audioPlayer = StreamingAudioPlayer.shared
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("TTS History")
+                    .font(.headline)
+
+                Text("(\(historyManager.entries.count) entries)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Spacer()
+
+                Button("Clear All") {
+                    stopPlayback()
+                    historyManager.clearAllHistory()
+                }
+                .disabled(historyManager.entries.isEmpty)
+            }
+            .padding()
+
+            Divider()
+
+            // Table or empty state
+            if historyManager.entries.isEmpty {
+                emptyStateView
+            } else {
+                HistoryTableView(
+                    entries: historyManager.entries,
+                    playingEntryId: $playingEntryId,
+                    onReplay: replayEntry,
+                    onDelete: deleteEntry
+                )
+            }
+
+            Divider()
+
+            // Footer with total cost
+            HStack {
+                Text("Total cost: \(historyManager.formattedTotalCost)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Spacer()
+
+                if playingEntryId != nil {
+                    Button("Stop") {
+                        stopPlayback()
+                    }
+                    .controlSize(.small)
+                }
+            }
+            .padding()
+        }
+        .frame(minWidth: 600, minHeight: 400)
+    }
+
+    private var emptyStateView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 48))
+                .foregroundColor(.secondary)
+
+            Text("No History Yet")
+                .font(.headline)
+
+            Text("Use the hotkey to speak text.\nIt will appear here.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    private func replayEntry(_ entry: HistoryEntry) {
+        // If already playing this entry, stop it
+        if playingEntryId == entry.id {
+            stopPlayback()
+            return
+        }
+
+        // Stop any current playback
+        stopPlayback()
+
+        // Get audio data and play
+        guard let audioData = historyManager.getAudioData(for: entry) else {
+            print("[Tyler] Failed to load audio for history entry")
+            return
+        }
+
+        playingEntryId = entry.id
+        audioPlayer.reset()
+
+        // Enqueue the audio data in chunks for smooth playback
+        let chunkSize = 8192
+        var offset = 0
+        while offset < audioData.count {
+            let end = min(offset + chunkSize, audioData.count)
+            let chunk = audioData[offset..<end]
+            audioPlayer.enqueue(pcmData: Data(chunk))
+            offset = end
+        }
+
+        // Estimate duration and reset state when done
+        // Duration = bytes / (sampleRate * bytesPerSample)
+        // 24kHz, 16-bit mono = 24000 * 2 = 48000 bytes/second
+        let durationSeconds = Double(audioData.count) / 48000.0
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + durationSeconds + 0.5) { [self] in
+            if self.playingEntryId == entry.id {
+                self.playingEntryId = nil
+            }
+        }
+    }
+
+    private func deleteEntry(_ entry: HistoryEntry) {
+        if playingEntryId == entry.id {
+            stopPlayback()
+        }
+        historyManager.deleteEntry(entry)
+    }
+
+    private func stopPlayback() {
+        audioPlayer.stop()
+        playingEntryId = nil
+    }
+}


### PR DESCRIPTION
Implements a complete history feature for tracking TTS requests and their associated audio files. Adds a new History window accessible via the menu with ability to replay and manage past TTS sessions. Refactors TTSService to properly accumulate and return audio data and token counts with fallback token estimation based on input text length. Updates AppState to persist TTS results to disk after successful synthesis for later retrieval.

The feature respects disk space constraints (500MB max) and maintains a maximum of 100 history entries, automatically cleaning up oldest entries when limits are exceeded. Each entry tracks timestamp, input text, voice used, token count, calculated cost, and the path to the associated audio file.