### PR TITLE
Add audio player UI with waveform visualization

### DIFF
--- a/Sources/Hibiki/AppDelegate.swift
+++ b/Sources/Hibiki/AppDelegate.swift
@@ -1,6 +1,7 @@
 import Cocoa
 import SwiftUI
 import KeyboardShortcuts
+import Combine
 
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var statusItem: NSStatusItem!
@@ -8,6 +9,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var menu: NSMenu!
     private var settingsWindow: NSWindow?
     private var historyWindow: NSWindow?
+    private var audioPlayerPanel: NSPanel?
+    private var playingObserver: AnyCancellable?
+    private var keyboardMonitor: Any?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Ensure only one instance is running
@@ -27,6 +31,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
         // Check permissions on launch
         PermissionManager.shared.checkAllPermissions()
+
+        // Observe playing state to show/hide audio player panel
+        playingObserver = AppState.shared.$isPlaying
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isPlaying in
+                if isPlaying {
+                    self?.showAudioPlayerPanel()
+                } else {
+                    self?.hideAudioPlayerPanel()
+                }
+            }
     }
 
     /// Returns true if this is the only instance, false if another instance is already running
@@ -158,8 +173,94 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
+    // MARK: - Audio Player Panel
+
+    private func showAudioPlayerPanel() {
+        if audioPlayerPanel == nil {
+            createAudioPlayerPanel()
+        }
+
+        // Position panel below the status bar item
+        positionPanelBelowMenuBar()
+        audioPlayerPanel?.orderFront(nil)
+
+        // Install global keyboard monitor for S and Esc
+        installKeyboardMonitor()
+    }
+
+    private func hideAudioPlayerPanel() {
+        audioPlayerPanel?.orderOut(nil)
+        removeKeyboardMonitor()
+    }
+
+    private func createAudioPlayerPanel() {
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 340, height: 90),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .transient]
+        panel.isMovableByWindowBackground = true
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+
+        let contentView = AudioPlayerPanel(audioLevelMonitor: AppState.shared.audioLevelMonitor)
+            .environmentObject(AppState.shared)
+        panel.contentView = NSHostingView(rootView: contentView)
+
+        audioPlayerPanel = panel
+    }
+
+    private func positionPanelBelowMenuBar() {
+        guard let panel = audioPlayerPanel,
+              let button = statusItem.button,
+              let buttonWindow = button.window else { return }
+
+        // Get the button's frame in screen coordinates
+        let buttonFrameInWindow = button.convert(button.bounds, to: nil)
+        let buttonFrameOnScreen = buttonWindow.convertToScreen(buttonFrameInWindow)
+
+        // Position panel below the button, centered
+        let panelWidth = panel.frame.width
+        let x = buttonFrameOnScreen.midX - panelWidth / 2
+        let y = buttonFrameOnScreen.minY - panel.frame.height - 4
+
+        panel.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    private func installKeyboardMonitor() {
+        guard keyboardMonitor == nil else { return }
+
+        keyboardMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
+            guard AppState.shared.isPlaying else { return }
+
+            // Check for 'S' key (stop)
+            if event.keyCode == 1 && event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty {
+                DispatchQueue.main.async {
+                    AppState.shared.stopPlayback()
+                }
+            }
+            // Check for Escape key (cancel)
+            else if event.keyCode == 53 {
+                DispatchQueue.main.async {
+                    AppState.shared.stopPlayback()
+                }
+            }
+        }
+    }
+
+    private func removeKeyboardMonitor() {
+        if let monitor = keyboardMonitor {
+            NSEvent.removeMonitor(monitor)
+            keyboardMonitor = nil
+        }
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         StreamingAudioPlayer.shared.stop()
+        removeKeyboardMonitor()
     }
 
     // MARK: - NSWindowDelegate

--- a/Sources/Hibiki/Audio/AudioLevelMonitor.swift
+++ b/Sources/Hibiki/Audio/AudioLevelMonitor.swift
@@ -1,0 +1,71 @@
+import AVFoundation
+import Combine
+
+final class AudioLevelMonitor: ObservableObject {
+    @Published var currentLevel: Float = 0.0
+
+    private var tapInstalled = false
+    private weak var monitoredEngine: AVAudioEngine?
+
+    func startMonitoring(engine: AVAudioEngine) {
+        guard !tapInstalled else { return }
+
+        monitoredEngine = engine
+        let mixer = engine.mainMixerNode
+        let format = mixer.outputFormat(forBus: 0)
+
+        // Install tap to sample audio levels
+        mixer.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            let level = self?.calculateLevel(buffer: buffer) ?? 0
+            DispatchQueue.main.async {
+                self?.currentLevel = level
+            }
+        }
+        tapInstalled = true
+    }
+
+    func stopMonitoring() {
+        guard tapInstalled, let engine = monitoredEngine else { return }
+
+        engine.mainMixerNode.removeTap(onBus: 0)
+        tapInstalled = false
+        monitoredEngine = nil
+
+        DispatchQueue.main.async {
+            self.currentLevel = 0
+        }
+    }
+
+    private func calculateLevel(buffer: AVAudioPCMBuffer) -> Float {
+        // Handle different PCM formats
+        let frameLength = Int(buffer.frameLength)
+        guard frameLength > 0 else { return 0 }
+
+        var sum: Float = 0
+
+        if let floatData = buffer.floatChannelData {
+            // Float32 format
+            let channelData = floatData.pointee
+            for i in 0..<frameLength {
+                let sample = channelData[i]
+                sum += sample * sample
+            }
+        } else if let int16Data = buffer.int16ChannelData {
+            // Int16 format - normalize to -1.0 to 1.0
+            let channelData = int16Data.pointee
+            for i in 0..<frameLength {
+                let normalized = Float(channelData[i]) / Float(Int16.max)
+                sum += normalized * normalized
+            }
+        } else {
+            return 0
+        }
+
+        // Calculate RMS
+        let rms = sqrt(sum / Float(frameLength))
+
+        // Normalize to 0-1 range with some amplification for visibility
+        // Speech typically has low RMS values, so we amplify
+        return min(1.0, rms * 8.0)
+    }
+}

--- a/Sources/Hibiki/Core/AppState.swift
+++ b/Sources/Hibiki/Core/AppState.swift
@@ -12,11 +12,19 @@ final class AppState: ObservableObject {
     @AppStorage("selectedVoice") var selectedVoice: String = TTSVoice.coral.rawValue
     @AppStorage("openaiAPIKey") var apiKey: String = ""
 
+    // Audio level monitor for waveform visualization
+    let audioLevelMonitor = AudioLevelMonitor()
+
     private let ttsService = TTSService()
     private let audioPlayer = StreamingAudioPlayer.shared
     private let accessibilityManager = AccessibilityManager.shared
 
     private let logger = DebugLogger.shared
+
+    // Track state for history save on stop
+    private var accumulatedAudioData = Data()
+    private var pendingHistorySave: (text: String, voice: String, inputTokens: Int)?
+    private var historySaved = false
 
     init() {
         // Default API key from environment variable if not set
@@ -87,12 +95,31 @@ final class AppState: ObservableObject {
             isPlaying = true
             isLoading = false
 
+            // Reset tracking state
+            accumulatedAudioData = Data()
+            pendingHistorySave = nil
+            historySaved = false
+
             // Reset audio player for fresh playback
             audioPlayer.reset()
 
             // Get the voice enum from stored string
             let voice = TTSVoice(rawValue: selectedVoice) ?? .coral
             logger.info("Using voice: \(voice.rawValue)", source: "AppState")
+
+            // Store pending history info for save on stop
+            pendingHistorySave = (text: text, voice: voice.rawValue, inputTokens: 0)
+
+            // Set up playback completion callback
+            audioPlayer.onPlaybackComplete = { [weak self] in
+                self?.logger.info("Audio playback complete", source: "AppState")
+                Task { @MainActor in
+                    self?.handlePlaybackComplete()
+                }
+            }
+
+            // Start audio level monitoring
+            audioLevelMonitor.startMonitoring(engine: audioPlayer.audioEngine)
 
             // Start streaming TTS
             logger.info("Starting TTS stream...", source: "AppState")
@@ -103,25 +130,19 @@ final class AppState: ObservableObject {
                 onAudioChunk: { [weak self] data in
                     self?.logger.debug("Received audio chunk: \(data.count) bytes", source: "AppState")
                     self?.audioPlayer.enqueue(pcmData: data)
+                    self?.accumulatedAudioData.append(data)
                 },
                 onComplete: { [weak self] result in
                     self?.logger.info("TTS stream complete, audio size: \(result.audioData.count) bytes, inputTokens: \(result.inputTokens)", source: "AppState")
 
-                    // Save to history
-                    HistoryManager.shared.addEntry(
-                        text: text,
-                        voice: voice.rawValue,
-                        inputTokens: result.inputTokens,
-                        audioData: result.audioData
-                    )
-                    self?.logger.info("Saved to history", source: "AppState")
-
-                    Task { @MainActor in
-                        // Small delay to let audio finish playing
-                        try? await Task.sleep(nanoseconds: 500_000_000)
-                        self?.isPlaying = false
-                        self?.currentText = nil
+                    // Update pending history with actual token count
+                    if var pending = self?.pendingHistorySave {
+                        pending.inputTokens = result.inputTokens
+                        self?.pendingHistorySave = pending
                     }
+
+                    // Mark stream as complete so player can detect when audio finishes
+                    self?.audioPlayer.markStreamComplete()
                 },
                 onError: { [weak self] error in
                     self?.logger.error("TTS error: \(error.localizedDescription)", source: "AppState")
@@ -129,6 +150,7 @@ final class AppState: ObservableObject {
                         self?.errorMessage = error.localizedDescription
                         self?.isLoading = false
                         self?.isPlaying = false
+                        self?.audioLevelMonitor.stopMonitoring()
                     }
                 }
             )
@@ -141,9 +163,55 @@ final class AppState: ObservableObject {
     }
 
     func stopPlayback() {
+        logger.info("Stopping playback", source: "AppState")
+
+        // Stop audio and TTS
         audioPlayer.stop()
         ttsService.cancel()
+        audioLevelMonitor.stopMonitoring()
+
+        // Save to history if we have accumulated audio and haven't saved yet
+        if !historySaved, let pending = pendingHistorySave, !accumulatedAudioData.isEmpty {
+            logger.info("Saving partial audio to history (\(accumulatedAudioData.count) bytes)", source: "AppState")
+            HistoryManager.shared.addEntry(
+                text: pending.text,
+                voice: pending.voice,
+                inputTokens: pending.inputTokens,
+                audioData: accumulatedAudioData
+            )
+            historySaved = true
+        }
+
+        // Clear state
         isPlaying = false
         currentText = nil
+        accumulatedAudioData = Data()
+        pendingHistorySave = nil
+    }
+
+    @MainActor
+    private func handlePlaybackComplete() {
+        guard isPlaying else { return }
+
+        logger.info("Playback completed naturally", source: "AppState")
+
+        // Save to history if not already saved
+        if !historySaved, let pending = pendingHistorySave, !accumulatedAudioData.isEmpty {
+            logger.info("Saving to history (\(accumulatedAudioData.count) bytes)", source: "AppState")
+            HistoryManager.shared.addEntry(
+                text: pending.text,
+                voice: pending.voice,
+                inputTokens: pending.inputTokens,
+                audioData: accumulatedAudioData
+            )
+            historySaved = true
+        }
+
+        // Stop monitoring and clear state
+        audioLevelMonitor.stopMonitoring()
+        isPlaying = false
+        currentText = nil
+        accumulatedAudioData = Data()
+        pendingHistorySave = nil
     }
 }

--- a/Sources/Hibiki/Views/AudioPlayerPanel.swift
+++ b/Sources/Hibiki/Views/AudioPlayerPanel.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct AudioPlayerPanel: View {
+    @EnvironmentObject var appState: AppState
+    @ObservedObject var audioLevelMonitor: AudioLevelMonitor
+
+    var body: some View {
+        VStack(spacing: 12) {
+            // Waveform visualization
+            WaveformView(level: audioLevelMonitor.currentLevel, barCount: 50)
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+
+            // Bottom row: voice info and controls
+            HStack {
+                // Voice indicator
+                HStack(spacing: 6) {
+                    Image(systemName: "mic.fill")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+
+                    Text(voiceDisplayName)
+                        .font(.system(size: 13))
+                        .foregroundColor(.primary)
+                }
+
+                Spacer()
+
+                // Control buttons
+                HStack(spacing: 8) {
+                    Button(action: { appState.stopPlayback() }) {
+                        HStack(spacing: 4) {
+                            Text("Stop")
+                            Text("S")
+                                .font(.system(size: 10, weight: .medium))
+                                .padding(.horizontal, 4)
+                                .padding(.vertical, 2)
+                                .background(Color.primary.opacity(0.15))
+                                .cornerRadius(3)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.primary)
+
+                    Button(action: { appState.stopPlayback() }) {
+                        HStack(spacing: 4) {
+                            Text("Cancel")
+                            Text("esc")
+                                .font(.system(size: 10, weight: .medium))
+                                .padding(.horizontal, 4)
+                                .padding(.vertical, 2)
+                                .background(Color.primary.opacity(0.15))
+                                .cornerRadius(3)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.primary)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 12)
+        }
+        .frame(width: 340)
+        .background(
+            VisualEffectView(material: .hudWindow, blendingMode: .behindWindow)
+        )
+        .cornerRadius(12)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.primary.opacity(0.1), lineWidth: 1)
+        )
+    }
+
+    private var voiceDisplayName: String {
+        // Capitalize the voice name
+        appState.selectedVoice.capitalized
+    }
+}
+
+#Preview {
+    AudioPlayerPanel(audioLevelMonitor: AudioLevelMonitor())
+        .environmentObject(AppState.shared)
+        .padding()
+}

--- a/Sources/Hibiki/Views/VisualEffectView.swift
+++ b/Sources/Hibiki/Views/VisualEffectView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct VisualEffectView: NSViewRepresentable {
+    let material: NSVisualEffectView.Material
+    let blendingMode: NSVisualEffectView.BlendingMode
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = material
+        view.blendingMode = blendingMode
+        view.state = .active
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+        nsView.material = material
+        nsView.blendingMode = blendingMode
+    }
+}

--- a/Sources/Hibiki/Views/WaveformView.swift
+++ b/Sources/Hibiki/Views/WaveformView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct WaveformView: View {
+    let level: Float
+    let barCount: Int
+
+    @State private var phases: [Double] = []
+
+    init(level: Float, barCount: Int = 40) {
+        self.level = level
+        self.barCount = barCount
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 1.5) {
+            ForEach(0..<barCount, id: \.self) { index in
+                RoundedRectangle(cornerRadius: 1)
+                    .fill(Color.primary.opacity(0.8))
+                    .frame(width: 2.5, height: barHeight(for: index))
+            }
+        }
+        .frame(height: 32)
+        .onAppear {
+            // Initialize random phases for organic look
+            phases = (0..<barCount).map { _ in Double.random(in: 0...Double.pi * 2) }
+        }
+    }
+
+    private func barHeight(for index: Int) -> CGFloat {
+        let minHeight: CGFloat = 3
+        let maxHeight: CGFloat = 32
+
+        // Create a wave pattern that varies across bars
+        let normalizedIndex = Double(index) / Double(barCount)
+
+        // Multiple sine waves for organic look
+        let phase = phases.indices.contains(index) ? phases[index] : 0
+        let wave1 = sin(normalizedIndex * Double.pi * 3 + phase)
+        let wave2 = sin(normalizedIndex * Double.pi * 7 + phase * 0.5) * 0.5
+        let wave3 = sin(normalizedIndex * Double.pi * 11 + phase * 0.3) * 0.25
+
+        let combinedWave = (wave1 + wave2 + wave3) / 1.75 // Normalize to roughly -1 to 1
+        let normalizedWave = (combinedWave + 1) / 2 // Convert to 0-1
+
+        // Scale by audio level
+        let levelScale = CGFloat(max(0.1, level)) // Minimum activity
+        let height = minHeight + (maxHeight - minHeight) * normalizedWave * levelScale
+
+        return max(minHeight, height)
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        WaveformView(level: 0.0)
+        WaveformView(level: 0.3)
+        WaveformView(level: 0.6)
+        WaveformView(level: 1.0)
+    }
+    .padding()
+    .background(Color.black)
+}


### PR DESCRIPTION
## Summary

Implemented a floating audio player panel that appears below the menu bar during TTS playback, featuring real-time waveform visualization with animated bars, voice indicator, and Stop/Cancel buttons. The panel vanishes when playback completes or the user stops it. Also replaced the 500ms delay hack with accurate playback completion detection.

## Changes

- **AudioPlayerPanel.swift**: Main floating panel with waveform, voice name, and control buttons
- **AudioLevelMonitor.swift**: Real-time audio level monitoring via AVAudioEngine tap
- **WaveformView.swift**: 50-bar animated waveform responding to audio levels
- **VisualEffectView.swift**: SwiftUI wrapper for macOS blur effects
- **StreamingAudioPlayer**: Exposed audio engine, added playback completion tracking
- **AppState**: Integrated level monitor, improved history save logic for stopped playback
- **AppDelegate**: Panel window management, global keyboard shortcuts (S and Esc)

## Test Plan

- Select text in any app and press Option+F
- Verify panel appears below menu bar with animated waveform
- Press S or Esc to stop - verify audio stops and history entry saved
- Let audio complete naturally - verify panel vanishes automatically
- Verify keyboard shortcuts work globally

🤖 Generated with [Claude Code](https://claude.com/claude-code)