### PR TITLE
Add LLM summarization feature with Shift+Option+F hotkey

### DIFF
--- a/Sources/Hibiki/Core/LLMService.swift
+++ b/Sources/Hibiki/Core/LLMService.swift
@@ -1,0 +1,292 @@
+import Foundation
+
+struct LLMResult {
+    let summarizedText: String
+    let inputTokens: Int
+    let outputTokens: Int
+    let model: String
+}
+
+enum LLMModel: String, CaseIterable, Identifiable {
+    case gpt5Nano = "gpt-5-nano"
+    case gpt5Mini = "gpt-5-mini"
+    case gpt52 = "gpt-5.2"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .gpt5Nano: return "GPT-5 Nano"
+        case .gpt5Mini: return "GPT-5 Mini"
+        case .gpt52: return "GPT-5.2"
+        }
+    }
+}
+
+enum LLMError: Error, LocalizedError {
+    case missingAPIKey
+    case invalidURL
+    case apiError(statusCode: Int, message: String?)
+    case decodingError
+    case emptyResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            return "OpenAI API key is not configured"
+        case .invalidURL:
+            return "Invalid API URL"
+        case .apiError(let code, let msg):
+            return "API error: HTTP \(code)\(msg.map { " - \($0)" } ?? "")"
+        case .decodingError:
+            return "Failed to decode API response"
+        case .emptyResponse:
+            return "LLM returned empty response"
+        }
+    }
+}
+
+final class LLMService {
+    private let logger = DebugLogger.shared
+    private var currentTask: URLSessionTask?
+
+    func summarize(
+        text: String,
+        model: LLMModel,
+        systemPrompt: String,
+        apiKey: String
+    ) async throws -> LLMResult {
+        guard !apiKey.isEmpty else {
+            throw LLMError.missingAPIKey
+        }
+
+        guard let url = URL(string: "https://api.openai.com/v1/chat/completions") else {
+            throw LLMError.invalidURL
+        }
+
+        logger.info("Starting LLM summarization with model: \(model.rawValue)", source: "LLMService")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 60  // 60 second timeout
+
+        let body: [String: Any] = [
+            "model": model.rawValue,
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": text]
+            ],
+            "max_completion_tokens": 8192
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        
+        logger.info("Sending request to OpenAI API...", source: "LLMService")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        logger.info("Received response from OpenAI API (\(data.count) bytes)", source: "LLMService")
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw LLMError.apiError(statusCode: 0, message: "Invalid response")
+        }
+
+        logger.info("LLM API response status: \(httpResponse.statusCode)", source: "LLMService")
+        
+        // Log raw response for debugging
+        if let rawResponse = String(data: data, encoding: .utf8) {
+            logger.info("LLM raw response: \(rawResponse.prefix(2000))", source: "LLMService")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let errorMessage = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            let message = (errorMessage?["error"] as? [String: Any])?["message"] as? String
+            logger.error("LLM API error: HTTP \(httpResponse.statusCode) - \(message ?? "unknown")", source: "LLMService")
+            throw LLMError.apiError(statusCode: httpResponse.statusCode, message: message)
+        }
+
+        // Parse response
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            logger.error("Failed to parse JSON response", source: "LLMService")
+            throw LLMError.decodingError
+        }
+        
+        guard let choices = json["choices"] as? [[String: Any]], !choices.isEmpty else {
+            logger.error("No choices in response. Keys: \(json.keys.sorted())", source: "LLMService")
+            throw LLMError.decodingError
+        }
+        
+        let firstChoice = choices[0]
+        logger.debug("First choice keys: \(firstChoice.keys.sorted())", source: "LLMService")
+        
+        guard let message = firstChoice["message"] as? [String: Any] else {
+            logger.error("No message in first choice. Choice: \(firstChoice)", source: "LLMService")
+            throw LLMError.decodingError
+        }
+        
+        logger.debug("Message keys: \(message.keys.sorted())", source: "LLMService")
+        
+        // Try to get content - it might be nil or empty in some cases
+        let content: String
+        if let messageContent = message["content"] as? String {
+            logger.info("Got content string, length: \(messageContent.count), value: '\(messageContent.prefix(500))'", source: "LLMService")
+            content = messageContent
+        } else if message["content"] == nil || message["content"] is NSNull {
+            // Content is null - check for refusal or other fields
+            if let refusal = message["refusal"] as? String, !refusal.isEmpty {
+                logger.error("LLM refused request: \(refusal)", source: "LLMService")
+                throw LLMError.apiError(statusCode: 200, message: "Request refused: \(refusal)")
+            }
+            logger.error("Message content is null. Full message: \(message)", source: "LLMService")
+            throw LLMError.emptyResponse
+        } else {
+            logger.error("Content is not a string. Type: \(type(of: message["content"]))", source: "LLMService")
+            throw LLMError.decodingError
+        }
+
+        let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedContent.isEmpty else {
+            logger.error("LLM returned empty content after trimming. Original length: \(content.count)", source: "LLMService")
+            throw LLMError.emptyResponse
+        }
+
+        // Extract usage
+        let usage = json["usage"] as? [String: Any]
+        let inputTokens = usage?["prompt_tokens"] as? Int ?? 0
+        let outputTokens = usage?["completion_tokens"] as? Int ?? 0
+
+        logger.info("LLM summarization complete: \(trimmedContent.count) chars, \(inputTokens) input tokens, \(outputTokens) output tokens", source: "LLMService")
+
+        return LLMResult(
+            summarizedText: trimmedContent,
+            inputTokens: inputTokens,
+            outputTokens: outputTokens,
+            model: model.rawValue
+        )
+    }
+
+    func cancel() {
+        currentTask?.cancel()
+        currentTask = nil
+    }
+    
+    /// Streaming summarization - yields text chunks as they arrive
+    func summarizeStreaming(
+        text: String,
+        model: LLMModel,
+        systemPrompt: String,
+        apiKey: String,
+        onChunk: @escaping (String) -> Void
+    ) async throws -> LLMResult {
+        guard !apiKey.isEmpty else {
+            throw LLMError.missingAPIKey
+        }
+        
+        guard let url = URL(string: "https://api.openai.com/v1/chat/completions") else {
+            throw LLMError.invalidURL
+        }
+        
+        logger.info("Starting streaming LLM summarization with model: \(model.rawValue)", source: "LLMService")
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 120  // Longer timeout for streaming
+        
+        let body: [String: Any] = [
+            "model": model.rawValue,
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": text]
+            ],
+            "max_completion_tokens": 8192,
+            "stream": true,
+            "stream_options": ["include_usage": true]
+        ]
+        
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        
+        logger.info("Sending streaming request to OpenAI API...", source: "LLMService")
+        
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw LLMError.apiError(statusCode: 0, message: "Invalid response")
+        }
+        
+        logger.info("Streaming response status: \(httpResponse.statusCode)", source: "LLMService")
+        
+        guard httpResponse.statusCode == 200 else {
+            // For error responses, we need to collect all bytes
+            var errorData = Data()
+            for try await byte in bytes {
+                errorData.append(byte)
+            }
+            let errorMessage = try? JSONSerialization.jsonObject(with: errorData) as? [String: Any]
+            let message = (errorMessage?["error"] as? [String: Any])?["message"] as? String
+            logger.error("LLM API error: HTTP \(httpResponse.statusCode) - \(message ?? "unknown")", source: "LLMService")
+            throw LLMError.apiError(statusCode: httpResponse.statusCode, message: message)
+        }
+        
+        var fullContent = ""
+        var inputTokens = 0
+        var outputTokens = 0
+        
+        // Process SSE stream
+        for try await line in bytes.lines {
+            // Skip empty lines and comments
+            guard line.hasPrefix("data: ") else { continue }
+            
+            let jsonString = String(line.dropFirst(6)) // Remove "data: " prefix
+            
+            // Check for stream end
+            if jsonString == "[DONE]" {
+                logger.debug("Stream complete signal received", source: "LLMService")
+                break
+            }
+            
+            guard let jsonData = jsonString.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+                continue
+            }
+            
+            // Extract usage from final chunk (when stream_options.include_usage is true)
+            if let usage = json["usage"] as? [String: Any] {
+                inputTokens = usage["prompt_tokens"] as? Int ?? inputTokens
+                outputTokens = usage["completion_tokens"] as? Int ?? outputTokens
+            }
+            
+            // Extract content delta
+            if let choices = json["choices"] as? [[String: Any]],
+               let firstChoice = choices.first,
+               let delta = firstChoice["delta"] as? [String: Any],
+               let content = delta["content"] as? String {
+                fullContent += content
+                logger.debug("Stream chunk: '\(content)'", source: "LLMService")
+                
+                // Call the chunk handler on main thread
+                await MainActor.run {
+                    onChunk(content)
+                }
+            }
+        }
+        
+        let trimmedContent = fullContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedContent.isEmpty else {
+            logger.error("Streaming LLM returned empty content", source: "LLMService")
+            throw LLMError.emptyResponse
+        }
+        
+        logger.info("Streaming summarization complete: \(trimmedContent.count) chars, \(inputTokens) input tokens, \(outputTokens) output tokens", source: "LLMService")
+        
+        return LLMResult(
+            summarizedText: trimmedContent,
+            inputTokens: inputTokens,
+            outputTokens: outputTokens,
+            model: model.rawValue
+        )
+    }
+}

--- a/Sources/Hibiki/Views/AudioPlayerPanel.swift
+++ b/Sources/Hibiki/Views/AudioPlayerPanel.swift
@@ -5,24 +5,81 @@ struct AudioPlayerPanel: View {
     @ObservedObject var audioLevelMonitor: AudioLevelMonitor
 
     var body: some View {
-        VStack(spacing: 12) {
-            // Waveform visualization
+        VStack(spacing: 8) {
+            // Waveform visualization (always shown)
             WaveformView(level: audioLevelMonitor.currentLevel, barCount: 50)
                 .frame(maxWidth: .infinity)
                 .padding(.horizontal, 16)
                 .padding(.top, 8)
+            
+            // Streaming summary text below waveform (during summarization)
+            if appState.isSummarizing || !appState.streamingSummary.isEmpty {
+                ScrollViewReader { proxy in
+                    ScrollView(.vertical, showsIndicators: true) {
+                        Text(appState.streamingSummary.isEmpty ? " " : appState.streamingSummary)
+                            .font(.system(size: 12))
+                            .foregroundColor(.primary.opacity(0.9))
+                            .frame(maxWidth: .infinity, alignment: .topLeading)
+                            .padding(8)
+                            .id("streamingText")
+                    }
+                    .frame(height: 80)
+                    .frame(maxWidth: .infinity)
+                    .background(Color.primary.opacity(0.05))
+                    .cornerRadius(6)
+                    .padding(.horizontal, 12)
+                    .onChange(of: appState.streamingSummary) { _, _ in
+                        withAnimation(.easeOut(duration: 0.1)) {
+                            proxy.scrollTo("streamingText", anchor: .bottom)
+                        }
+                    }
+                }
+            }
+
+            // Speed control row
+            HStack(spacing: 8) {
+                Image(systemName: "gauge.with.dots.needle.33percent")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                
+                Slider(
+                    value: Binding(
+                        get: { appState.playbackSpeed },
+                        set: { appState.updatePlaybackSpeed($0) }
+                    ),
+                    in: 1.0...2.5,
+                    step: 0.1
+                )
+                .controlSize(.small)
+                
+                Text(String(format: "%.1fx", appState.playbackSpeed))
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundColor(.primary)
+                    .frame(width: 36, alignment: .trailing)
+            }
+            .padding(.horizontal, 16)
 
             // Bottom row: voice info and controls
             HStack {
-                // Voice indicator
+                // Voice indicator or summarizing status
                 HStack(spacing: 6) {
-                    Image(systemName: "mic.fill")
-                        .font(.system(size: 12))
-                        .foregroundColor(.secondary)
+                    if appState.isSummarizing {
+                        ProgressView()
+                            .scaleEffect(0.6)
+                            .frame(width: 12, height: 12)
+                        
+                        Text("Summarizing...")
+                            .font(.system(size: 13))
+                            .foregroundColor(.primary)
+                    } else {
+                        Image(systemName: "mic.fill")
+                            .font(.system(size: 12))
+                            .foregroundColor(.secondary)
 
-                    Text(voiceDisplayName)
-                        .font(.system(size: 13))
-                        .foregroundColor(.primary)
+                        Text(voiceDisplayName)
+                            .font(.system(size: 13))
+                            .foregroundColor(.primary)
+                    }
                 }
 
                 Spacer()
@@ -62,6 +119,7 @@ struct AudioPlayerPanel: View {
             .padding(.bottom, 12)
         }
         .frame(width: 340)
+        .fixedSize(horizontal: false, vertical: true)
         .background(
             VisualEffectView(material: .hudWindow, blendingMode: .behindWindow)
         )

--- a/Sources/Hibiki/Views/HistoryTableView.swift
+++ b/Sources/Hibiki/Views/HistoryTableView.swift
@@ -15,27 +15,78 @@ struct HistoryTableView: View {
             }
             .width(min: 120, ideal: 140)
 
-            TableColumn("Text") { entry in
-                Text(entry.truncatedText)
-                    .font(.system(.caption))
-                    .lineLimit(2)
-                    .help(entry.text)
+            TableColumn("Type") { entry in
+                HStack(spacing: 4) {
+                    if entry.wasSummarized {
+                        Image(systemName: "sparkles")
+                            .foregroundColor(.purple)
+                        Text("AI")
+                            .font(.caption2)
+                            .foregroundColor(.purple)
+                    } else {
+                        Image(systemName: "speaker.wave.2")
+                            .foregroundColor(.secondary)
+                        Text("TTS")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .help(entry.wasSummarized ? "Summarized with AI before TTS" : "Direct text-to-speech")
             }
-            .width(min: 200, ideal: 300)
+            .width(50)
+
+            TableColumn("Original Text") { entry in
+                HoverableTextCell(
+                    text: entry.text,
+                    displayText: truncateText(entry.text, maxLength: 80),
+                    title: "Original Text"
+                )
+            }
+            .width(min: 120, ideal: 180)
+            
+            TableColumn("Summary") { entry in
+                if let summary = entry.summarizedText {
+                    HoverableTextCell(
+                        text: summary,
+                        displayText: truncateText(summary, maxLength: 80),
+                        title: "Summary",
+                        textColor: .purple
+                    )
+                } else {
+                    Text("-")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .width(min: 120, ideal: 180)
 
             TableColumn("Voice") { entry in
                 Text(entry.voice.capitalized)
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
-            .width(60)
+            .width(55)
 
-            TableColumn("Cost") { entry in
-                Text(entry.formattedCost)
+            TableColumn("LLM") { entry in
+                Text(entry.formattedLLMCost)
                     .font(.system(.caption, design: .monospaced))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(entry.wasSummarized ? .orange : .secondary)
             }
             .width(60)
+
+            TableColumn("TTS") { entry in
+                Text(entry.formattedTTSCost)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundColor(.purple)
+            }
+            .width(60)
+            
+            TableColumn("Total") { entry in
+                Text(entry.formattedCost)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundColor(.blue)
+            }
+            .width(65)
 
             TableColumn("Actions") { entry in
                 HStack(spacing: 8) {
@@ -58,8 +109,84 @@ struct HistoryTableView: View {
                     .help("Delete")
                 }
             }
-            .width(80)
+            .width(60)
         }
         .tableStyle(.inset(alternatesRowBackgrounds: true))
+    }
+    
+    /// Truncate text to a maximum length with ellipsis
+    private func truncateText(_ text: String, maxLength: Int) -> String {
+        if text.count > maxLength {
+            return String(text.prefix(maxLength)) + "..."
+        }
+        return text
+    }
+}
+
+/// A text cell that shows a popover with full text on hover
+struct HoverableTextCell: View {
+    let text: String
+    let displayText: String
+    var title: String = ""
+    var textColor: Color = .primary
+    
+    @State private var isHovering = false
+    @State private var showPopover = false
+    @State private var hoverTask: Task<Void, Never>?
+    
+    var body: some View {
+        Text(displayText)
+            .font(.system(.caption))
+            .lineLimit(2)
+            .foregroundColor(textColor)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .onHover { hovering in
+                isHovering = hovering
+                if hovering {
+                    // Start a delayed task to show popover
+                    hoverTask = Task {
+                        try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 second delay
+                        if !Task.isCancelled && isHovering {
+                            await MainActor.run {
+                                showPopover = true
+                            }
+                        }
+                    }
+                } else {
+                    // Cancel pending task and hide popover
+                    hoverTask?.cancel()
+                    hoverTask = nil
+                    showPopover = false
+                }
+            }
+            .popover(isPresented: $showPopover, arrowEdge: .bottom) {
+                VStack(alignment: .leading, spacing: 8) {
+                    if !title.isEmpty {
+                        HStack {
+                            Text(title)
+                                .font(.headline)
+                                .foregroundColor(.secondary)
+                            Spacer()
+                            Text("\(text.count) chars")
+                                .font(.caption)
+                                .foregroundColor(.secondary.opacity(0.7))
+                        }
+                    }
+                    
+                    ScrollView(.vertical, showsIndicators: true) {
+                        VStack(alignment: .leading) {
+                            Text(text)
+                                .font(.system(size: 13))
+                                .lineLimit(nil)
+                                .textSelection(.enabled)
+                                .multilineTextAlignment(.leading)
+                        }
+                        .frame(width: 380, alignment: .leading)
+                    }
+                    .frame(width: 395, height: min(max(CGFloat(text.count) / 2.5, 80), 350))
+                }
+                .padding(12)
+                .frame(width: 420)
+            }
     }
 }

--- a/Sources/Hibiki/Views/Tabs/ConfigurationTab.swift
+++ b/Sources/Hibiki/Views/Tabs/ConfigurationTab.swift
@@ -48,12 +48,104 @@ struct ConfigurationTab: View {
                     .padding(.vertical, 4)
                 }
 
-                // Hotkey Section
-                GroupBox("Hotkey") {
+                // Playback Speed Section
+                GroupBox("Playback Speed") {
                     VStack(alignment: .leading, spacing: 8) {
-                        KeyboardShortcuts.Recorder("Trigger TTS:", name: .triggerTTS)
+                        HStack {
+                            Text("Default Speed:")
+                            
+                            Slider(
+                                value: $appState.playbackSpeed,
+                                in: 1.0...2.5,
+                                step: 0.1
+                            )
+                            
+                            Text(String(format: "%.1fx", appState.playbackSpeed))
+                                .font(.system(.body, design: .monospaced))
+                                .frame(width: 45, alignment: .trailing)
+                        }
+                        
+                        HStack(spacing: 12) {
+                            ForEach([1.0, 1.5, 2.0, 2.5], id: \.self) { speed in
+                                Button(String(format: "%.1fx", speed)) {
+                                    appState.playbackSpeed = speed
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
+                                .tint(appState.playbackSpeed == speed ? .accentColor : nil)
+                            }
+                        }
 
-                        Text("Select text in any app, then press this shortcut to read it aloud.")
+                        Text("Speed can also be adjusted during playback.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                }
+
+                // Hotkey Section
+                GroupBox("Hotkeys") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            KeyboardShortcuts.Recorder("Trigger TTS:", name: .triggerTTS)
+                            Text("Select text in any app, then press this shortcut to read it aloud.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+
+                        Divider()
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            KeyboardShortcuts.Recorder("Summarize + TTS:", name: .triggerSummarizeTTS)
+                            Text("Summarize text with AI before reading aloud.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+
+                // Summarization Section
+                GroupBox("Summarization") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Picker("Model:", selection: $appState.summarizationModel) {
+                            ForEach(LLMModel.allCases) { model in
+                                Text(model.displayName).tag(model.rawValue)
+                            }
+                        }
+                        .pickerStyle(.menu)
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("System Prompt:")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+
+                            TextEditor(text: $appState.summarizationPrompt)
+                                .font(.system(.body, design: .monospaced))
+                                .frame(height: 100)
+                                .scrollContentBackground(.hidden)
+                                .background(Color(NSColor.textBackgroundColor))
+                                .cornerRadius(4)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                                )
+                        }
+
+                        HStack {
+                            Button("Reset to Default") {
+                                appState.summarizationPrompt = """
+                                    Summarize the following text concisely while preserving the key information. \
+                                    The summary should be suitable for text-to-speech, so write in complete sentences \
+                                    and avoid bullet points or special formatting. Keep it under 3 paragraphs.
+                                    """
+                            }
+                            .controlSize(.small)
+
+                            Spacer()
+                        }
+
+                        Text("The summarization prompt controls how text is condensed before TTS.")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }


### PR DESCRIPTION
## Summary
- New hotkey (Shift+Option+F) summarizes selected text using GPT-5 models before TTS
- Supports gpt-5-nano, gpt-5-mini, and gpt-5.2 with configurable system prompt
- Separate cost tracking for LLM and TTS operations
- Enhanced history table showing original text, summaries, and per-service costs
- Real-time streaming of LLM summaries with cancellation support

## Test Plan
- [ ] Test direct TTS (Option+F) still works
- [ ] Test summarize+TTS (Shift+Option+F) with gpt-5-nano
- [ ] Verify history table displays original and summarized text
- [ ] Check cost calculations for LLM and TTS separately
- [ ] Test changing model and system prompt in settings
- [ ] Verify error handling for API failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)