### PR TITLE
Add text chunking for long TTS and change stop to Option key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Hibiki
 
+```
+ _     _ _     _ _    _
+| |   (_) |   (_) |  (_)
+| |__  _| |__  _| | ___
+| '_ \| | '_ \| | |/ / |
+| | | | | |_) | |   <| |
+|_| |_|_|_.__/|_|_|\_\_|
+```
+
 A macOS menu bar app that reads selected text aloud using OpenAI's text-to-speech API.
 
 ## Features

--- a/Sources/Hibiki/AppDelegate.swift
+++ b/Sources/Hibiki/AppDelegate.swift
@@ -242,17 +242,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private func installKeyboardMonitor() {
         guard keyboardMonitor == nil else { return }
 
-        keyboardMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
+        keyboardMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { event in
             guard AppState.shared.isPlaying || AppState.shared.isSummarizing else { return }
 
-            // Check for 'S' key (stop)
-            if event.keyCode == 1 && event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty {
-                DispatchQueue.main.async {
-                    AppState.shared.stopPlayback()
+            // Check for Option key alone (stop) - triggered on flagsChanged
+            if event.type == .flagsChanged {
+                let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                // Option key pressed alone (no other modifiers)
+                if flags == .option {
+                    DispatchQueue.main.async {
+                        AppState.shared.stopPlayback()
+                    }
                 }
             }
             // Check for Escape key (cancel)
-            else if event.keyCode == 53 {
+            else if event.type == .keyDown && event.keyCode == 53 {
                 DispatchQueue.main.async {
                     AppState.shared.stopPlayback()
                 }

--- a/Sources/Hibiki/Core/TextChunker.swift
+++ b/Sources/Hibiki/Core/TextChunker.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// Splits text into chunks suitable for TTS processing
+enum TextChunker {
+    /// Default maximum chunk size (characters)
+    /// OpenAI TTS limit is 4096, we use 2500 for safety margin
+    static let defaultMaxLength = 2500
+
+    /// Minimum chunk size to avoid tiny fragments
+    private static let minimumChunkSize = 100
+
+    /// Split text into chunks, respecting natural boundaries
+    /// - Parameters:
+    ///   - text: The input text to split
+    ///   - maxLength: Maximum characters per chunk (default: 2500)
+    /// - Returns: Array of text chunks, each under maxLength
+    static func chunk(_ text: String, maxLength: Int = defaultMaxLength) -> [String] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // If text fits in one chunk, return as-is
+        guard trimmed.count > maxLength else {
+            return trimmed.isEmpty ? [] : [trimmed]
+        }
+
+        var chunks: [String] = []
+        var remaining = trimmed
+
+        while !remaining.isEmpty {
+            if remaining.count <= maxLength {
+                let finalChunk = remaining.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !finalChunk.isEmpty {
+                    chunks.append(finalChunk)
+                }
+                break
+            }
+
+            // Find best split point within maxLength
+            let searchRange = String(remaining.prefix(maxLength))
+
+            // Try sentence boundaries first (. ! ? followed by space/newline, or paragraph break)
+            if let splitIndex = findSentenceBoundary(in: searchRange) {
+                let chunk = String(remaining.prefix(splitIndex))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if !chunk.isEmpty {
+                    chunks.append(chunk)
+                }
+                remaining = String(remaining.dropFirst(splitIndex))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                continue
+            }
+
+            // Try clause boundaries (, ; :)
+            if let splitIndex = findClauseBoundary(in: searchRange) {
+                let chunk = String(remaining.prefix(splitIndex))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if !chunk.isEmpty {
+                    chunks.append(chunk)
+                }
+                remaining = String(remaining.dropFirst(splitIndex))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                continue
+            }
+
+            // Fall back to word boundary
+            if let splitIndex = findWordBoundary(in: searchRange) {
+                let chunk = String(remaining.prefix(splitIndex))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if !chunk.isEmpty {
+                    chunks.append(chunk)
+                }
+                remaining = String(remaining.dropFirst(splitIndex))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                continue
+            }
+
+            // Last resort: hard cut at maxLength
+            let chunk = String(remaining.prefix(maxLength))
+            chunks.append(chunk)
+            remaining = String(remaining.dropFirst(maxLength))
+        }
+
+        return chunks.filter { !$0.isEmpty }
+    }
+
+    /// Find the last sentence boundary in the text
+    /// Returns the index after the terminator (where to split)
+    private static func findSentenceBoundary(in text: String) -> Int? {
+        // Sentence terminators followed by whitespace
+        let terminators = [". ", ".\n", ".\t", "! ", "!\n", "? ", "?\n", "\n\n"]
+
+        var bestIndex: Int? = nil
+
+        for terminator in terminators {
+            if let range = text.range(of: terminator, options: .backwards) {
+                let index = text.distance(from: text.startIndex, to: range.upperBound)
+                if bestIndex == nil || index > bestIndex! {
+                    bestIndex = index
+                }
+            }
+        }
+
+        // Also check for sentence end at the very end of text
+        let endTerminators = [".", "!", "?"]
+        for terminator in endTerminators {
+            if text.hasSuffix(terminator) {
+                let index = text.count
+                if bestIndex == nil || index > bestIndex! {
+                    bestIndex = index
+                }
+            }
+        }
+
+        // Require minimum chunk size to avoid tiny fragments
+        if let idx = bestIndex, idx >= minimumChunkSize {
+            return idx
+        }
+        return nil
+    }
+
+    /// Find the last clause boundary in the text
+    private static func findClauseBoundary(in text: String) -> Int? {
+        let separators = [", ", "; ", ": "]
+        var bestIndex: Int? = nil
+
+        for separator in separators {
+            if let range = text.range(of: separator, options: .backwards) {
+                let index = text.distance(from: text.startIndex, to: range.upperBound)
+                if bestIndex == nil || index > bestIndex! {
+                    bestIndex = index
+                }
+            }
+        }
+
+        if let idx = bestIndex, idx >= minimumChunkSize {
+            return idx
+        }
+        return nil
+    }
+
+    /// Find the last word boundary (space) in the text
+    private static func findWordBoundary(in text: String) -> Int? {
+        if let range = text.range(of: " ", options: .backwards) {
+            let index = text.distance(from: text.startIndex, to: range.upperBound)
+            // Lower threshold for word boundaries since it's our last natural option
+            if index >= 50 {
+                return index
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/Hibiki/Views/AudioPlayerPanel.swift
+++ b/Sources/Hibiki/Views/AudioPlayerPanel.swift
@@ -89,7 +89,7 @@ struct AudioPlayerPanel: View {
                     Button(action: { appState.stopPlayback() }) {
                         HStack(spacing: 4) {
                             Text("Stop")
-                            Text("S")
+                            Text("⌥")
                                 .font(.system(size: 10, weight: .medium))
                                 .padding(.horizontal, 4)
                                 .padding(.vertical, 2)

--- a/Sources/Hibiki/Views/Tabs/ConfigurationTab.swift
+++ b/Sources/Hibiki/Views/Tabs/ConfigurationTab.swift
@@ -6,9 +6,30 @@ struct ConfigurationTab: View {
     @State private var showKey = false
     @State private var hasAccessibility = false
 
+    private let asciiArt = """
+         _     _ _     _ _    _
+        | |   (_) |   (_) |  (_)
+        | |__  _| |__  _| | ___
+        | '_ \\| | '_ \\| | |/ / |
+        | | | | | |_) | |   <| |
+        |_| |_|_|_.__/|_|_|\\_\\_|
+        """
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
+                // ASCII Art Header
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(asciiArt)
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity)
+                    Text("Designed by RobertTLange")
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary)
+                }
+                .padding(.bottom, 4)
+
                 // API Key Section
                 GroupBox("OpenAI API Key") {
                     VStack(alignment: .leading, spacing: 8) {


### PR DESCRIPTION
Add support for long text by chunking TTS requests and change the stop hotkey.

**Changes:**
- TextChunker utility intelligently splits long text into 2500-char chunks (under OpenAI's 4096 limit)
- TTSService now processes chunks sequentially while maintaining seamless audio streaming
- Stop hotkey changed from 'S' to Option key (⌥) for better ergonomics
- Added Hibiki ASCII art to settings and README

Audio plays continuously without gaps between chunks, and token counts accumulate across the entire request.