### PR TITLE
Add translation hotkeys with customizable settings

### DIFF
--- a/Sources/Hibiki/Core/AppState.swift
+++ b/Sources/Hibiki/Core/AppState.swift
@@ -7,9 +7,11 @@ final class AppState: ObservableObject {
     @Published var isPlaying = false
     @Published var isLoading = false
     @Published var isSummarizing = false
+    @Published var isTranslating = false
     @Published var currentText: String?
     @Published var errorMessage: String?
     @Published var streamingSummary: String = ""  // Accumulates streaming summary text
+    @Published var streamingTranslation: String = ""  // Accumulates streaming translation text
 
     @AppStorage("selectedVoice") var selectedVoice: String = TTSVoice.coral.rawValue
     @AppStorage("openaiAPIKey") var apiKey: String = ""
@@ -23,6 +25,14 @@ final class AppState: ObservableObject {
         and avoid bullet points or special formatting. Keep it under 3 paragraphs.
         """
 
+    // Translation settings
+    @AppStorage("targetLanguage") var targetLanguage: String = TargetLanguage.none.rawValue
+    @AppStorage("translationModel") var translationModelSetting: String = LLMModel.gpt5Nano.rawValue
+    @AppStorage("translationPrompt") var translationPrompt: String = """
+        Translate the following text to {language}. Preserve the meaning, tone, and style. \
+        Output only the translation without any explanations or notes.
+        """
+
     // Audio level monitor for waveform visualization
     let audioLevelMonitor = AudioLevelMonitor()
 
@@ -31,6 +41,7 @@ final class AppState: ObservableObject {
     private let audioPlayer = StreamingAudioPlayer.shared
     private let accessibilityManager = AccessibilityManager.shared
     private var summarizationTask: Task<Void, Never>?
+    private var translationTask: Task<Void, Never>?
 
     private let logger = DebugLogger.shared
 
@@ -43,7 +54,12 @@ final class AppState: ObservableObject {
         summarizedText: String?,
         llmInputTokens: Int?,
         llmOutputTokens: Int?,
-        llmModel: String?
+        llmModel: String?,
+        translatedText: String?,
+        translationInputTokens: Int?,
+        translationOutputTokens: Int?,
+        translationModel: String?,
+        targetLanguage: String?
     )?
     private var historySaved = false
 
@@ -72,6 +88,25 @@ final class AppState: ObservableObject {
             self?.summarizationTask?.cancel()
             self?.summarizationTask = Task { @MainActor in
                 await self?.handleSummarizeTTSPressed()
+            }
+        }
+
+        logger.debug("Setting up hotkey handler for .triggerTranslateTTS", source: "AppState")
+        KeyboardShortcuts.onKeyDown(for: .triggerTranslateTTS) { [weak self] in
+            self?.logger.info("Translate+TTS hotkey pressed!", source: "AppState")
+            self?.translationTask?.cancel()
+            self?.translationTask = Task { @MainActor in
+                await self?.handleTranslateTTSPressed()
+            }
+        }
+
+        logger.debug("Setting up hotkey handler for .triggerSummarizeTranslateTTS", source: "AppState")
+        KeyboardShortcuts.onKeyDown(for: .triggerSummarizeTranslateTTS) { [weak self] in
+            self?.logger.info("Summarize+Translate+TTS hotkey pressed!", source: "AppState")
+            self?.summarizationTask?.cancel()
+            self?.translationTask?.cancel()
+            self?.summarizationTask = Task { @MainActor in
+                await self?.handleSummarizeTranslateTTSPressed()
             }
         }
     }
@@ -146,7 +181,12 @@ final class AppState: ObservableObject {
                 summarizedText: nil,
                 llmInputTokens: nil,
                 llmOutputTokens: nil,
-                llmModel: nil
+                llmModel: nil,
+                translatedText: nil,
+                translationInputTokens: nil,
+                translationOutputTokens: nil,
+                translationModel: nil,
+                targetLanguage: nil
             )
 
             // Set up playback completion callback
@@ -295,7 +335,12 @@ final class AppState: ObservableObject {
                 summarizedText: llmResult.summarizedText,
                 llmInputTokens: llmResult.inputTokens,
                 llmOutputTokens: llmResult.outputTokens,
-                llmModel: llmResult.model
+                llmModel: llmResult.model,
+                translatedText: nil,
+                translationInputTokens: nil,
+                translationOutputTokens: nil,
+                translationModel: nil,
+                targetLanguage: nil
             )
 
             audioPlayer.onPlaybackComplete = { [weak self] in
@@ -349,6 +394,344 @@ final class AppState: ObservableObject {
         }
     }
 
+    @MainActor
+    func handleTranslateTTSPressed() async {
+        logger.debug("handleTranslateTTSPressed called", source: "AppState")
+
+        // If already playing, stop
+        if isPlaying {
+            logger.info("Already playing, stopping playback", source: "AppState")
+            stopPlayback()
+            return
+        }
+
+        do {
+            isLoading = true
+            errorMessage = nil
+
+            // Get selected text
+            logger.debug("Attempting to get selected text for translation...", source: "AppState")
+            let text = try accessibilityManager.getSelectedText()
+            logger.debug("Got text: \(text ?? "nil")", source: "AppState")
+
+            guard let text = text, !text.isEmpty else {
+                logger.error("No text selected", source: "AppState")
+                errorMessage = "No text selected"
+                isLoading = false
+                return
+            }
+
+            logger.info("Selected text for translation (\(text.count) chars)", source: "AppState")
+
+            // Check API key
+            var effectiveApiKey = apiKey
+            if effectiveApiKey.isEmpty {
+                if let envKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"], !envKey.isEmpty {
+                    effectiveApiKey = envKey
+                    apiKey = envKey
+                    logger.info("Loaded API key from environment variable", source: "AppState")
+                } else {
+                    logger.error("API key is empty!", source: "AppState")
+                    errorMessage = "No API key configured. Enter key in Settings."
+                    isLoading = false
+                    return
+                }
+            }
+
+            let language = TargetLanguage(rawValue: targetLanguage) ?? .none
+            var textForTTS = text
+            var translationResult: TranslationResult? = nil
+
+            // Translate if target language is set
+            if language != .none {
+                isTranslating = true
+                let translationModel = LLMModel(rawValue: translationModelSetting) ?? .gpt5Nano
+                logger.info("Translating to \(language.languageName) with model: \(translationModel.rawValue)", source: "AppState")
+
+                streamingTranslation = ""
+
+                translationResult = try await llmService.translateStreaming(
+                    text: text,
+                    targetLanguage: language,
+                    model: translationModel,
+                    systemPrompt: translationPrompt,
+                    apiKey: effectiveApiKey,
+                    onChunk: { [weak self] chunk in
+                        guard let self = self else { return }
+                        self.logger.debug("Translation chunk received: \(chunk.count) chars", source: "AppState")
+                        self.streamingTranslation += chunk
+                    }
+                )
+
+                logger.info("Translation complete: \(translationResult!.translatedText.count) chars", source: "AppState")
+                textForTTS = translationResult!.translatedText
+                isTranslating = false
+            }
+
+            // Now proceed with TTS
+            currentText = textForTTS
+            isPlaying = true
+            isLoading = false
+
+            // Reset tracking state
+            accumulatedAudioData = Data()
+            pendingHistorySave = nil
+            historySaved = false
+
+            audioPlayer.reset()
+            audioPlayer.playbackSpeed = Float(playbackSpeed)
+
+            let voice = TTSVoice(rawValue: selectedVoice) ?? .coral
+            logger.info("Using voice: \(voice.rawValue)", source: "AppState")
+
+            // Store pending history with translation metadata
+            pendingHistorySave = (
+                text: text,  // Original text
+                voice: voice.rawValue,
+                inputTokens: 0,
+                summarizedText: nil,
+                llmInputTokens: nil,
+                llmOutputTokens: nil,
+                llmModel: nil,
+                translatedText: translationResult?.translatedText,
+                translationInputTokens: translationResult?.inputTokens,
+                translationOutputTokens: translationResult?.outputTokens,
+                translationModel: translationResult?.model,
+                targetLanguage: language != .none ? language.rawValue : nil
+            )
+
+            audioPlayer.onPlaybackComplete = { [weak self] in
+                self?.logger.info("Audio playback complete", source: "AppState")
+                Task { @MainActor in
+                    self?.handlePlaybackComplete()
+                }
+            }
+
+            audioLevelMonitor.startMonitoring(engine: audioPlayer.audioEngine)
+
+            // TTS the translated text
+            logger.info("Starting TTS stream for translated text...", source: "AppState")
+            ttsService.streamSpeech(
+                text: textForTTS,
+                voice: voice,
+                apiKey: effectiveApiKey,
+                onAudioChunk: { [weak self] data in
+                    self?.logger.debug("Received audio chunk: \(data.count) bytes", source: "AppState")
+                    self?.audioPlayer.enqueue(pcmData: data)
+                    self?.accumulatedAudioData.append(data)
+                },
+                onComplete: { [weak self] result in
+                    self?.logger.info("TTS stream complete, audio size: \(result.audioData.count) bytes, inputTokens: \(result.inputTokens)", source: "AppState")
+
+                    if var pending = self?.pendingHistorySave {
+                        pending.inputTokens = result.inputTokens
+                        self?.pendingHistorySave = pending
+                    }
+
+                    self?.audioPlayer.markStreamComplete()
+                },
+                onError: { [weak self] error in
+                    self?.logger.error("TTS error: \(error.localizedDescription)", source: "AppState")
+                    Task { @MainActor in
+                        self?.errorMessage = error.localizedDescription
+                        self?.isLoading = false
+                        self?.isPlaying = false
+                        self?.isTranslating = false
+                        self?.audioLevelMonitor.stopMonitoring()
+                    }
+                }
+            )
+        } catch {
+            logger.error("Translate+TTS exception: \(error.localizedDescription)", source: "AppState")
+            errorMessage = error.localizedDescription
+            isLoading = false
+            isPlaying = false
+            isTranslating = false
+        }
+    }
+
+    @MainActor
+    func handleSummarizeTranslateTTSPressed() async {
+        logger.debug("handleSummarizeTranslateTTSPressed called", source: "AppState")
+
+        // If already playing, stop
+        if isPlaying {
+            logger.info("Already playing, stopping playback", source: "AppState")
+            stopPlayback()
+            return
+        }
+
+        do {
+            isLoading = true
+            isSummarizing = true
+            errorMessage = nil
+
+            // Get selected text
+            logger.debug("Attempting to get selected text for summarize+translate...", source: "AppState")
+            let text = try accessibilityManager.getSelectedText()
+            logger.debug("Got text: \(text ?? "nil")", source: "AppState")
+
+            guard let text = text, !text.isEmpty else {
+                logger.error("No text selected", source: "AppState")
+                errorMessage = "No text selected"
+                isLoading = false
+                isSummarizing = false
+                return
+            }
+
+            logger.info("Selected text for summarize+translate (\(text.count) chars)", source: "AppState")
+
+            // Check API key
+            var effectiveApiKey = apiKey
+            if effectiveApiKey.isEmpty {
+                if let envKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"], !envKey.isEmpty {
+                    effectiveApiKey = envKey
+                    apiKey = envKey
+                    logger.info("Loaded API key from environment variable", source: "AppState")
+                } else {
+                    logger.error("API key is empty!", source: "AppState")
+                    errorMessage = "No API key configured. Enter key in Settings."
+                    isLoading = false
+                    isSummarizing = false
+                    return
+                }
+            }
+
+            // Summarize text with streaming
+            let model = LLMModel(rawValue: summarizationModel) ?? .gpt5Nano
+            logger.info("Summarizing with model: \(model.rawValue)", source: "AppState")
+
+            streamingSummary = ""
+
+            let llmResult = try await llmService.summarizeStreaming(
+                text: text,
+                model: model,
+                systemPrompt: summarizationPrompt,
+                apiKey: effectiveApiKey,
+                onChunk: { [weak self] chunk in
+                    guard let self = self else { return }
+                    self.logger.debug("LLM chunk received: \(chunk.count) chars", source: "AppState")
+                    self.streamingSummary += chunk
+                }
+            )
+
+            logger.info("Summarization complete: \(llmResult.summarizedText.count) chars", source: "AppState")
+            isSummarizing = false
+
+            // Now translate if target language is set
+            let language = TargetLanguage(rawValue: targetLanguage) ?? .none
+            var textForTTS = llmResult.summarizedText
+            var translationResult: TranslationResult? = nil
+
+            if language != .none {
+                isTranslating = true
+                let translationModel = LLMModel(rawValue: translationModelSetting) ?? .gpt5Nano
+                logger.info("Translating summarized text to \(language.languageName) with model: \(translationModel.rawValue)", source: "AppState")
+
+                streamingTranslation = ""
+
+                translationResult = try await llmService.translateStreaming(
+                    text: llmResult.summarizedText,
+                    targetLanguage: language,
+                    model: translationModel,
+                    systemPrompt: translationPrompt,
+                    apiKey: effectiveApiKey,
+                    onChunk: { [weak self] chunk in
+                        guard let self = self else { return }
+                        self.logger.debug("Translation chunk received: \(chunk.count) chars", source: "AppState")
+                        self.streamingTranslation += chunk
+                    }
+                )
+
+                logger.info("Translation complete: \(translationResult!.translatedText.count) chars", source: "AppState")
+                textForTTS = translationResult!.translatedText
+                isTranslating = false
+            }
+
+            // Now proceed with TTS
+            currentText = textForTTS
+            isPlaying = true
+            isLoading = false
+
+            // Reset tracking state
+            accumulatedAudioData = Data()
+            pendingHistorySave = nil
+            historySaved = false
+
+            audioPlayer.reset()
+            audioPlayer.playbackSpeed = Float(playbackSpeed)
+
+            let voice = TTSVoice(rawValue: selectedVoice) ?? .coral
+            logger.info("Using voice: \(voice.rawValue)", source: "AppState")
+
+            // Store pending history with both summarization and translation metadata
+            pendingHistorySave = (
+                text: text,  // Original text
+                voice: voice.rawValue,
+                inputTokens: 0,
+                summarizedText: llmResult.summarizedText,
+                llmInputTokens: llmResult.inputTokens,
+                llmOutputTokens: llmResult.outputTokens,
+                llmModel: llmResult.model,
+                translatedText: translationResult?.translatedText,
+                translationInputTokens: translationResult?.inputTokens,
+                translationOutputTokens: translationResult?.outputTokens,
+                translationModel: translationResult?.model,
+                targetLanguage: language != .none ? language.rawValue : nil
+            )
+
+            audioPlayer.onPlaybackComplete = { [weak self] in
+                self?.logger.info("Audio playback complete", source: "AppState")
+                Task { @MainActor in
+                    self?.handlePlaybackComplete()
+                }
+            }
+
+            audioLevelMonitor.startMonitoring(engine: audioPlayer.audioEngine)
+
+            // TTS the final text
+            logger.info("Starting TTS stream for summarized+translated text...", source: "AppState")
+            ttsService.streamSpeech(
+                text: textForTTS,
+                voice: voice,
+                apiKey: effectiveApiKey,
+                onAudioChunk: { [weak self] data in
+                    self?.logger.debug("Received audio chunk: \(data.count) bytes", source: "AppState")
+                    self?.audioPlayer.enqueue(pcmData: data)
+                    self?.accumulatedAudioData.append(data)
+                },
+                onComplete: { [weak self] result in
+                    self?.logger.info("TTS stream complete, audio size: \(result.audioData.count) bytes, inputTokens: \(result.inputTokens)", source: "AppState")
+
+                    if var pending = self?.pendingHistorySave {
+                        pending.inputTokens = result.inputTokens
+                        self?.pendingHistorySave = pending
+                    }
+
+                    self?.audioPlayer.markStreamComplete()
+                },
+                onError: { [weak self] error in
+                    self?.logger.error("TTS error: \(error.localizedDescription)", source: "AppState")
+                    Task { @MainActor in
+                        self?.errorMessage = error.localizedDescription
+                        self?.isLoading = false
+                        self?.isPlaying = false
+                        self?.isSummarizing = false
+                        self?.isTranslating = false
+                        self?.audioLevelMonitor.stopMonitoring()
+                    }
+                }
+            )
+        } catch {
+            logger.error("Summarize+Translate+TTS exception: \(error.localizedDescription)", source: "AppState")
+            errorMessage = error.localizedDescription
+            isLoading = false
+            isPlaying = false
+            isSummarizing = false
+            isTranslating = false
+        }
+    }
+
     /// Update playback speed in real-time (also persists the setting)
     func updatePlaybackSpeed(_ speed: Double) {
         playbackSpeed = speed
@@ -359,11 +742,13 @@ final class AppState: ObservableObject {
     func stopPlayback() {
         logger.info("Stopping playback", source: "AppState")
 
-        // Cancel ongoing summarization task
+        // Cancel ongoing summarization and translation tasks
         summarizationTask?.cancel()
         summarizationTask = nil
+        translationTask?.cancel()
+        translationTask = nil
         llmService.cancel()
-        
+
         // Stop audio and TTS
         audioPlayer.stop()
         ttsService.cancel()
@@ -380,7 +765,12 @@ final class AppState: ObservableObject {
                 summarizedText: pending.summarizedText,
                 llmInputTokens: pending.llmInputTokens,
                 llmOutputTokens: pending.llmOutputTokens,
-                llmModel: pending.llmModel
+                llmModel: pending.llmModel,
+                translatedText: pending.translatedText,
+                translationInputTokens: pending.translationInputTokens,
+                translationOutputTokens: pending.translationOutputTokens,
+                translationModel: pending.translationModel,
+                targetLanguage: pending.targetLanguage
             )
             historySaved = true
         }
@@ -388,8 +778,10 @@ final class AppState: ObservableObject {
         // Clear state
         isPlaying = false
         isSummarizing = false
+        isTranslating = false
         currentText = nil
         streamingSummary = ""
+        streamingTranslation = ""
         accumulatedAudioData = Data()
         pendingHistorySave = nil
     }
@@ -411,7 +803,12 @@ final class AppState: ObservableObject {
                 summarizedText: pending.summarizedText,
                 llmInputTokens: pending.llmInputTokens,
                 llmOutputTokens: pending.llmOutputTokens,
-                llmModel: pending.llmModel
+                llmModel: pending.llmModel,
+                translatedText: pending.translatedText,
+                translationInputTokens: pending.translationInputTokens,
+                translationOutputTokens: pending.translationOutputTokens,
+                translationModel: pending.translationModel,
+                targetLanguage: pending.targetLanguage
             )
             historySaved = true
         }
@@ -421,6 +818,7 @@ final class AppState: ObservableObject {
         isPlaying = false
         currentText = nil
         streamingSummary = ""
+        streamingTranslation = ""
         accumulatedAudioData = Data()
         pendingHistorySave = nil
     }

--- a/Sources/Hibiki/Core/HistoryManager.swift
+++ b/Sources/Hibiki/Core/HistoryManager.swift
@@ -44,7 +44,12 @@ final class HistoryManager {
         summarizedText: String? = nil,
         llmInputTokens: Int? = nil,
         llmOutputTokens: Int? = nil,
-        llmModel: String? = nil
+        llmModel: String? = nil,
+        translatedText: String? = nil,
+        translationInputTokens: Int? = nil,
+        translationOutputTokens: Int? = nil,
+        translationModel: String? = nil,
+        targetLanguage: String? = nil
     ) -> HistoryEntry {
         let audioFileName = "\(UUID().uuidString).pcm"
         let audioURL = audioDirectory.appendingPathComponent(audioFileName)
@@ -64,7 +69,12 @@ final class HistoryManager {
             summarizedText: summarizedText,
             llmInputTokens: llmInputTokens,
             llmOutputTokens: llmOutputTokens,
-            llmModel: llmModel
+            llmModel: llmModel,
+            translatedText: translatedText,
+            translationInputTokens: translationInputTokens,
+            translationOutputTokens: translationOutputTokens,
+            translationModel: translationModel,
+            targetLanguage: targetLanguage
         )
 
         DispatchQueue.main.async {

--- a/Sources/Hibiki/Core/UsageStatistics.swift
+++ b/Sources/Hibiki/Core/UsageStatistics.swift
@@ -6,12 +6,13 @@ struct DailyUsage: Identifiable, Sendable {
     let cost: Double
     let ttsCost: Double
     let llmCost: Double
+    let translationCost: Double
     let wordCount: Int
     let audioMinutes: Double
     let requestCount: Int
 
     static func empty(for date: Date) -> DailyUsage {
-        DailyUsage(id: date, date: date, cost: 0, ttsCost: 0, llmCost: 0, wordCount: 0, audioMinutes: 0, requestCount: 0)
+        DailyUsage(id: date, date: date, cost: 0, ttsCost: 0, llmCost: 0, translationCost: 0, wordCount: 0, audioMinutes: 0, requestCount: 0)
     }
 }
 
@@ -27,12 +28,14 @@ enum CostCategory: String, CaseIterable {
     case total = "Total"
     case tts = "TTS"
     case llm = "LLM"
-    
+    case translation = "Translation"
+
     var color: String {
         switch self {
         case .total: return "blue"
         case .tts: return "purple"
         case .llm: return "orange"
+        case .translation: return "skyblue"
         }
     }
 }
@@ -41,11 +44,12 @@ struct PeriodSummary: Sendable {
     let cost: Double
     let ttsCost: Double
     let llmCost: Double
+    let translationCost: Double
     let wordCount: Int
     let audioMinutes: Double
     let requestCount: Int
 
-    static let zero = PeriodSummary(cost: 0, ttsCost: 0, llmCost: 0, wordCount: 0, audioMinutes: 0, requestCount: 0)
+    static let zero = PeriodSummary(cost: 0, ttsCost: 0, llmCost: 0, translationCost: 0, wordCount: 0, audioMinutes: 0, requestCount: 0)
 }
 
 /// Thread-safe calculator that works with pre-fetched data
@@ -80,6 +84,7 @@ final class UsageStatisticsCalculator: Sendable {
                 let cost = dayEntries.reduce(0) { $0 + $1.cost }
                 let ttsCost = dayEntries.reduce(0) { $0 + $1.ttsCost }
                 let llmCost = dayEntries.reduce(0) { $0 + ($1.llmCost ?? 0) }
+                let translationCost = dayEntries.reduce(0) { $0 + ($1.translationCost ?? 0) }
                 let words = dayEntries.reduce(0) { $0 + $1.wordCount }
                 let minutes = calculateAudioMinutes(for: dayEntries)
 
@@ -89,6 +94,7 @@ final class UsageStatisticsCalculator: Sendable {
                     cost: cost,
                     ttsCost: ttsCost,
                     llmCost: llmCost,
+                    translationCost: translationCost,
                     wordCount: words,
                     audioMinutes: minutes,
                     requestCount: dayEntries.count
@@ -129,6 +135,7 @@ final class UsageStatisticsCalculator: Sendable {
             cost: entries.reduce(0) { $0 + $1.cost },
             ttsCost: entries.reduce(0) { $0 + $1.ttsCost },
             llmCost: entries.reduce(0) { $0 + ($1.llmCost ?? 0) },
+            translationCost: entries.reduce(0) { $0 + ($1.translationCost ?? 0) },
             wordCount: entries.reduce(0) { $0 + $1.wordCount },
             audioMinutes: calculateAudioMinutes(for: entries),
             requestCount: entries.count

--- a/Sources/Hibiki/Views/AudioPlayerPanel.swift
+++ b/Sources/Hibiki/Views/AudioPlayerPanel.swift
@@ -36,6 +36,30 @@ struct AudioPlayerPanel: View {
                 }
             }
 
+            // Streaming translation text below waveform (during translation)
+            if appState.isTranslating || !appState.streamingTranslation.isEmpty {
+                ScrollViewReader { proxy in
+                    ScrollView(.vertical, showsIndicators: true) {
+                        Text(appState.streamingTranslation.isEmpty ? " " : appState.streamingTranslation)
+                            .font(.system(size: 12))
+                            .foregroundColor(Color(red: 0.3, green: 0.55, blue: 0.85))
+                            .frame(maxWidth: .infinity, alignment: .topLeading)
+                            .padding(8)
+                            .id("streamingTranslation")
+                    }
+                    .frame(height: 80)
+                    .frame(maxWidth: .infinity)
+                    .background(Color(red: 0.3, green: 0.55, blue: 0.85).opacity(0.08))
+                    .cornerRadius(6)
+                    .padding(.horizontal, 12)
+                    .onChange(of: appState.streamingTranslation) { _, _ in
+                        withAnimation(.easeOut(duration: 0.1)) {
+                            proxy.scrollTo("streamingTranslation", anchor: .bottom)
+                        }
+                    }
+                }
+            }
+
             // Speed control row
             HStack(spacing: 8) {
                 Image(systemName: "gauge.with.dots.needle.33percent")
@@ -61,16 +85,24 @@ struct AudioPlayerPanel: View {
 
             // Bottom row: voice info and controls
             HStack {
-                // Voice indicator or summarizing status
+                // Voice indicator or summarizing/translating status
                 HStack(spacing: 6) {
                     if appState.isSummarizing {
                         ProgressView()
                             .scaleEffect(0.6)
                             .frame(width: 12, height: 12)
-                        
+
                         Text("Summarizing...")
                             .font(.system(size: 13))
                             .foregroundColor(.primary)
+                    } else if appState.isTranslating {
+                        ProgressView()
+                            .scaleEffect(0.6)
+                            .frame(width: 12, height: 12)
+
+                        Text("Translating...")
+                            .font(.system(size: 13))
+                            .foregroundColor(Color(red: 0.3, green: 0.55, blue: 0.85))
                     } else {
                         Image(systemName: "mic.fill")
                             .font(.system(size: 12))

--- a/Sources/Hibiki/Views/Tabs/ConfigurationTab.swift
+++ b/Sources/Hibiki/Views/Tabs/ConfigurationTab.swift
@@ -122,6 +122,24 @@ struct ConfigurationTab: View {
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                         }
+
+                        Divider()
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            KeyboardShortcuts.Recorder("Translate + TTS:", name: .triggerTranslateTTS)
+                            Text("Translate text to target language before reading aloud.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+
+                        Divider()
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            KeyboardShortcuts.Recorder("Summarize + Translate + TTS:", name: .triggerSummarizeTranslateTTS)
+                            Text("Summarize, then translate text before reading aloud.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
                     }
                     .padding(.vertical, 4)
                 }
@@ -167,6 +185,63 @@ struct ConfigurationTab: View {
                         }
 
                         Text("The summarization prompt controls how text is condensed before TTS.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                }
+
+                // Translation Section
+                GroupBox("Translation") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Picker("Target Language:", selection: $appState.targetLanguage) {
+                            ForEach(TargetLanguage.allCases) { language in
+                                Text(language.displayName).tag(language.rawValue)
+                            }
+                        }
+                        .pickerStyle(.menu)
+
+                        Picker("Model:", selection: $appState.translationModelSetting) {
+                            ForEach(LLMModel.allCases) { model in
+                                Text(model.displayName).tag(model.rawValue)
+                            }
+                        }
+                        .pickerStyle(.menu)
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("System Prompt:")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+
+                            TextEditor(text: $appState.translationPrompt)
+                                .font(.system(.body, design: .monospaced))
+                                .frame(height: 80)
+                                .scrollContentBackground(.hidden)
+                                .background(Color(NSColor.textBackgroundColor))
+                                .cornerRadius(4)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                                )
+                        }
+
+                        HStack {
+                            Button("Reset to Default") {
+                                appState.translationPrompt = """
+                                    Translate the following text to {language}. Preserve the meaning, tone, and style. \
+                                    Output only the translation without any explanations or notes.
+                                    """
+                            }
+                            .controlSize(.small)
+
+                            Spacer()
+
+                            Text("Use {language} as placeholder")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+
+                        Text("Select the language to translate text into before TTS. Set to \"None\" to disable translation.")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }

--- a/Sources/Hibiki/Views/Tabs/StatisticsTab.swift
+++ b/Sources/Hibiki/Views/Tabs/StatisticsTab.swift
@@ -56,7 +56,8 @@ struct StatisticsTab: View {
                                 .chartForegroundStyleScale([
                                     "Total": Color.blue,
                                     "TTS": Color.purple,
-                                    "LLM": Color.orange
+                                    "LLM": Color.orange,
+                                    "Translation": Color(red: 0.3, green: 0.55, blue: 0.85)
                                 ])
                                 .chartXAxis {
                                     AxisMarks(values: .stride(by: .day, count: 7)) { _ in
@@ -212,6 +213,7 @@ struct StatisticsTab: View {
             points.append(CostDataPoint(date: day.date, cost: day.cost, category: .total))
             points.append(CostDataPoint(date: day.date, cost: day.ttsCost, category: .tts))
             points.append(CostDataPoint(date: day.date, cost: day.llmCost, category: .llm))
+            points.append(CostDataPoint(date: day.date, cost: day.translationCost, category: .translation))
         }
         return points
     }
@@ -307,8 +309,15 @@ struct SummaryCard: View {
                         }
 
                         HStack {
+                            Image(systemName: "globe")
+                                .foregroundColor(Color(red: 0.3, green: 0.55, blue: 0.85))
+                            Text(String(format: "Trans: $%.4f", summary.translationCost))
+                            Spacer()
+                        }
+
+                        HStack {
                             Image(systemName: "text.alignleft")
-                                .foregroundColor(.green)
+                                .foregroundColor(.teal)
                             Text("\(summary.wordCount) words")
                             Spacer()
                         }


### PR DESCRIPTION
## Summary
- Added Option+L hotkey for translate + TTS and Shift+Option+L for summarize + translate + TTS
- Target language selection (None, English, Japanese, German) with model picker and editable system prompts
- Translation metadata and cost tracking in history and statistics
- Sky blue color scheme for translation UI elements

## Test Plan
- [ ] Set target language and press Option+L to translate text to target language before TTS
- [ ] Press Shift+Option+L to summarize, then translate before TTS
- [ ] Change translation model and system prompt in Configuration settings
- [ ] Verify translation costs appear in history table and statistics
- [ ] Test with target language set to "None" to skip translation

🤖 Generated with Claude Code