### PR TITLE
feat: add Do Not Disturb switch for global audio mute

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         ),
         .executableTarget(
             name: "Hibiki",
-            dependencies: ["KeyboardShortcuts", "HibikiPocketRuntime"],
+            dependencies: ["KeyboardShortcuts", "HibikiPocketRuntime", "HibikiCLICore"],
             path: "Sources/Hibiki",
             exclude: ["Resources/Info.plist"],
             resources: [

--- a/Sources/HibikiCLI/HibikiCLI.swift
+++ b/Sources/HibikiCLI/HibikiCLI.swift
@@ -69,6 +69,11 @@ struct HibikiCLI: ParsableCommand {
             throw ExitCode.failure
         }
 
+        if DoNotDisturbPolicy.isEnabled() {
+            print(DoNotDisturbPolicy.cliSuppressedNotice)
+            return
+        }
+
         let baseURL: URL
         do {
             baseURL = try request.url()

--- a/Sources/HibikiCLICore/DoNotDisturbPolicy.swift
+++ b/Sources/HibikiCLICore/DoNotDisturbPolicy.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public enum DoNotDisturbPolicy {
+    public static let defaultsKey = "doNotDisturbEnabled"
+    public static let sharedDefaultsSuiteName = "com.superlisten.hibiki"
+    public static let blockedRequestMessage = "Do Not Disturb is enabled in Hibiki."
+    public static let cliSuppressedNotice = "Do Not Disturb is ON in Hibiki. Request skipped."
+
+    public static func isEnabled(
+        defaults: UserDefaults = .standard,
+        sharedDefaults: UserDefaults? = UserDefaults(suiteName: sharedDefaultsSuiteName)
+    ) -> Bool {
+        if let sharedDefaults,
+           sharedDefaults.object(forKey: defaultsKey) != nil {
+            return sharedDefaults.bool(forKey: defaultsKey)
+        }
+
+        if defaults.object(forKey: defaultsKey) != nil {
+            return defaults.bool(forKey: defaultsKey)
+        }
+
+        return false
+    }
+
+    public static func setEnabled(
+        _ enabled: Bool,
+        defaults: UserDefaults = .standard,
+        sharedDefaults: UserDefaults? = UserDefaults(suiteName: sharedDefaultsSuiteName)
+    ) {
+        defaults.set(enabled, forKey: defaultsKey)
+        sharedDefaults?.set(enabled, forKey: defaultsKey)
+    }
+}

--- a/Tests/HibikiTests/DoNotDisturbPolicyTests.swift
+++ b/Tests/HibikiTests/DoNotDisturbPolicyTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import HibikiCLICore
+import XCTest
+
+final class DoNotDisturbPolicyTests: XCTestCase {
+    private var defaultsSuitesToCleanup: [String] = []
+
+    override func tearDown() {
+        for suiteName in defaultsSuitesToCleanup {
+            if let defaults = UserDefaults(suiteName: suiteName) {
+                defaults.removePersistentDomain(forName: suiteName)
+            }
+        }
+        defaultsSuitesToCleanup.removeAll()
+        super.tearDown()
+    }
+
+    func testIsEnabledDefaultsToFalseWhenNoValueExists() {
+        let defaults = makeDefaults()
+        let sharedDefaults = makeDefaults()
+
+        let enabled = DoNotDisturbPolicy.isEnabled(defaults: defaults, sharedDefaults: sharedDefaults)
+
+        XCTAssertFalse(enabled)
+    }
+
+    func testIsEnabledReadsFromSharedDefaultsWhenSet() {
+        let defaults = makeDefaults()
+        let sharedDefaults = makeDefaults()
+        sharedDefaults.set(true, forKey: DoNotDisturbPolicy.defaultsKey)
+
+        let enabled = DoNotDisturbPolicy.isEnabled(defaults: defaults, sharedDefaults: sharedDefaults)
+
+        XCTAssertTrue(enabled)
+    }
+
+    func testSetEnabledPersistsToBothDefaultsStores() {
+        let defaults = makeDefaults()
+        let sharedDefaults = makeDefaults()
+
+        DoNotDisturbPolicy.setEnabled(true, defaults: defaults, sharedDefaults: sharedDefaults)
+
+        XCTAssertEqual(defaults.object(forKey: DoNotDisturbPolicy.defaultsKey) as? Bool, true)
+        XCTAssertEqual(sharedDefaults.object(forKey: DoNotDisturbPolicy.defaultsKey) as? Bool, true)
+    }
+
+    func testIsEnabledFallsBackToDefaultsWhenSharedStoreHasNoValue() {
+        let defaults = makeDefaults()
+        let sharedDefaults = makeDefaults()
+        defaults.set(true, forKey: DoNotDisturbPolicy.defaultsKey)
+
+        let enabled = DoNotDisturbPolicy.isEnabled(defaults: defaults, sharedDefaults: sharedDefaults)
+
+        XCTAssertTrue(enabled)
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "DoNotDisturbPolicyTests.\(UUID().uuidString)"
+        defaultsSuitesToCleanup.append(suiteName)
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create defaults suite")
+            return .standard
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}


### PR DESCRIPTION
## What changed
- Added shared `DoNotDisturbPolicy` in `HibikiCLICore` for cross-target DND state + messages.
- Enforced DND in app request pipeline (`AppState`) for manual/hotkey + CLI ingress.
- Added queued-request safety guard to prevent stale queued work from bypassing DND.
- Added CLI pre-dispatch DND check so `hibiki` exits cleanly with a user-visible notice.
- Added menu bar Do Not Disturb row with an on/off `NSSwitch` and improved rightward alignment.
- Set startup behavior so each app launch defaults DND to OFF.
- Added policy unit tests in `DoNotDisturbPolicyTests`.

## Why
Issue #27 requested a one-click, global mute control that affects both hotkey and CLI flows without killing the app.

## How to test
1. Launch app, open menu bar, verify Do Not Disturb switch exists and starts OFF.
2. With DND OFF, trigger hotkey/CLI and verify audio plays.
3. Toggle DND ON, trigger hotkey/CLI and verify no audio is emitted; CLI prints suppression notice and exits successfully.
4. Toggle DND ON during active playback and verify playback stops immediately.
5. Run `swift test`.

## Verification
- `swift test` (36 tests, 0 failures)
