### PR TITLE
Add menubar speed and volume controls

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,13 +16,18 @@ let package = Package(
     ],
     targets: [
         .target(
+            name: "HibikiShared",
+            dependencies: [],
+            path: "Sources/HibikiShared"
+        ),
+        .target(
             name: "HibikiPocketRuntime",
             dependencies: [],
             path: "Sources/HibikiPocketRuntime"
         ),
         .executableTarget(
             name: "Hibiki",
-            dependencies: ["KeyboardShortcuts", "HibikiPocketRuntime", "HibikiCLICore"],
+            dependencies: ["KeyboardShortcuts", "HibikiPocketRuntime", "HibikiCLICore", "HibikiShared"],
             path: "Sources/Hibiki",
             exclude: ["Resources/Info.plist"],
             resources: [
@@ -38,7 +43,7 @@ let package = Package(
         ),
         .testTarget(
             name: "HibikiTests",
-            dependencies: ["HibikiPocketRuntime", "HibikiCLICore"],
+            dependencies: ["HibikiShared", "HibikiPocketRuntime", "HibikiCLICore"],
             path: "Tests/HibikiTests"
         ),
         .executableTarget(

--- a/Sources/Hibiki/AppDelegate.swift
+++ b/Sources/Hibiki/AppDelegate.swift
@@ -2,12 +2,12 @@ import Cocoa
 import SwiftUI
 import KeyboardShortcuts
 import Combine
+import HibikiShared
 
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var statusItem: NSStatusItem!
     private var popover: NSPopover!
     private var menu: NSMenu!
-    private var doNotDisturbMenuItem: NSMenuItem?
     private var recentTracksHeaderMenuItem: NSMenuItem?
     private var recentTrackMenuItems: [NSMenuItem] = []
     private var mainWindow: NSWindow?
@@ -15,7 +15,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var panelVisibilityObserver: AnyCancellable?
     private var collapsedObserver: AnyCancellable?
     private var menuPlaybackObserver: AnyCancellable?
-    private var doNotDisturbObserver: AnyCancellable?
     private var historyEntriesObserver: AnyCancellable?
     private var manualPanelPinObserver: AnyCancellable?
     private var keyboardMonitor: Any?
@@ -216,10 +215,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         menu.addItem(statusMenuItem)
 
         menu.addItem(NSMenuItem.separator())
-        let dndMenuItem = NSMenuItem()
-        dndMenuItem.view = makeDoNotDisturbMenuView()
-        menu.addItem(dndMenuItem)
-        doNotDisturbMenuItem = dndMenuItem
+        let playbackControlsMenuItem = NSMenuItem()
+        playbackControlsMenuItem.view = makePlaybackControlsMenuView()
+        menu.addItem(playbackControlsMenuItem)
 
         menu.addItem(NSMenuItem.separator())
         let recentTracksHeaderItem = NSMenuItem(title: "Recent Tracks", action: nil, keyEquivalent: "")
@@ -233,7 +231,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         menu.addItem(NSMenuItem(title: "Quit Hibiki", action: #selector(quitApp), keyEquivalent: "q"))
 
         refreshRecentTrackMenuItems()
-        refreshDoNotDisturbMenuItem()
 
         statusItem.menu = menu
 
@@ -342,12 +339,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 self?.refreshRecentTrackMenuItems()
             }
 
-        doNotDisturbObserver = AppState.shared.$isDoNotDisturbEnabled
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                self?.refreshDoNotDisturbMenuItem()
-            }
-
         historyEntriesObserver = HistoryManager.shared.entriesDidChange
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
@@ -355,16 +346,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             }
     }
 
-    private func makeDoNotDisturbMenuView() -> NSView {
+    private func makePlaybackControlsMenuView() -> NSView {
         let hostingView = NSHostingView(
-            rootView: DoNotDisturbToggleRow(appState: AppState.shared)
+            rootView: MenuPlaybackControlsView(appState: AppState.shared)
         )
-        hostingView.frame = NSRect(x: 0, y: 0, width: 250, height: 24)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 264, height: 92)
         return hostingView
-    }
-
-    private func refreshDoNotDisturbMenuItem() {
-        guard doNotDisturbMenuItem != nil else { return }
     }
 
     private func refreshRecentTrackMenuItems() {
@@ -852,26 +839,72 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 }
 
-private struct DoNotDisturbToggleRow: View {
+private struct MenuPlaybackControlsView: View {
     @ObservedObject var appState: AppState
+    private let labelWidth: CGFloat = 56
 
     var body: some View {
-        Toggle(
-            isOn: Binding(
-                get: { appState.isDoNotDisturbEnabled },
-                set: { enabled in
-                    Task { @MainActor in
-                        appState.setDoNotDisturbEnabled(enabled)
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle(
+                isOn: Binding(
+                    get: { appState.isDoNotDisturbEnabled },
+                    set: { enabled in
+                        Task { @MainActor in
+                            appState.setDoNotDisturbEnabled(enabled)
+                        }
                     }
-                }
-            )
-        ) {
-            Text("Do Not Disturb")
-                .foregroundColor(.primary)
+                )
+            ) {
+                Text("Do Not Disturb")
+                    .foregroundColor(.primary)
+            }
+            .toggleStyle(BlueMenuSwitchToggleStyle())
+            .accessibilityElement(children: .contain)
+
+            HStack(spacing: 8) {
+                Text("Speed")
+                    .foregroundColor(.primary)
+                    .frame(width: labelWidth, alignment: .leading)
+
+                Slider(
+                    value: Binding(
+                        get: { appState.playbackSpeed },
+                        set: { appState.updatePlaybackSpeed($0) }
+                    ),
+                    in: PlaybackSettings.speedRange,
+                    step: PlaybackSettings.speedStep
+                )
+
+                Text(PlaybackSettings.speedLabel(for: appState.playbackSpeed))
+                    .font(.system(.body, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .frame(width: 36, alignment: .trailing)
+            }
+
+            HStack(spacing: 8) {
+                Text("Volume")
+                    .foregroundColor(.primary)
+                    .frame(width: labelWidth, alignment: .leading)
+
+                FlatSlider(
+                    value: Binding(
+                        get: { appState.playbackVolume },
+                        set: { appState.updatePlaybackVolume($0) }
+                    ),
+                    range: 0.0...AppState.maxPlaybackVolume,
+                    step: 0.01
+                )
+                .frame(height: 12)
+
+                Text("\(Int(appState.playbackVolume * 100))%")
+                    .font(.system(.body, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .frame(width: 44, alignment: .trailing)
+            }
         }
-        .toggleStyle(BlueMenuSwitchToggleStyle())
         .padding(.horizontal, 16)
-        .frame(width: 250, height: 24)
+        .padding(.vertical, 8)
+        .frame(width: 264)
     }
 }
 

--- a/Sources/Hibiki/Core/AppState.swift
+++ b/Sources/Hibiki/Core/AppState.swift
@@ -3,6 +3,7 @@ import KeyboardShortcuts
 import NaturalLanguage
 import HibikiPocketRuntime
 import HibikiCLICore
+import HibikiShared
 
 /// Position options for the audio player panel
 enum PanelPosition: String, CaseIterable, Identifiable {
@@ -375,7 +376,13 @@ final class AppState: ObservableObject {
         if pocketManagedVenvPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             pocketManagedVenvPath = PocketTTSRuntimeManager.defaultVenvPath()
         }
-        let clampedVolume = min(Self.maxPlaybackVolume, max(0.0, playbackVolume))
+        let clampedSpeed = PlaybackSettings.clampedSpeed(playbackSpeed)
+        if clampedSpeed != playbackSpeed {
+            playbackSpeed = clampedSpeed
+        }
+        audioPlayer.playbackSpeed = Float(clampedSpeed)
+
+        let clampedVolume = PlaybackSettings.clampedVolume(playbackVolume, maxVolume: Self.maxPlaybackVolume)
         if clampedVolume != playbackVolume {
             playbackVolume = clampedVolume
         }
@@ -964,9 +971,10 @@ final class AppState: ObservableObject {
 
     /// Update playback speed in real-time (also persists the setting)
     func updatePlaybackSpeed(_ speed: Double) {
-        playbackSpeed = speed
-        audioPlayer.playbackSpeed = Float(speed)
-        logger.debug("Playback speed updated to \(speed)x", source: "AppState")
+        let clamped = PlaybackSettings.clampedSpeed(speed)
+        playbackSpeed = clamped
+        audioPlayer.playbackSpeed = Float(clamped)
+        logger.debug("Playback speed updated to \(clamped)x", source: "AppState")
     }
 
     @MainActor
@@ -1031,7 +1039,7 @@ final class AppState: ObservableObject {
 
     /// Update playback volume in real-time (also persists the setting)
     func updatePlaybackVolume(_ volume: Double) {
-        let clamped = min(Self.maxPlaybackVolume, max(0.0, volume))
+        let clamped = PlaybackSettings.clampedVolume(volume, maxVolume: Self.maxPlaybackVolume)
         playbackVolume = clamped
         audioPlayer.playbackVolume = Float(clamped)
         logger.debug("Playback volume updated to \(Int(clamped * 100))%", source: "AppState")

--- a/Sources/Hibiki/Views/AudioPlayerPanel.swift
+++ b/Sources/Hibiki/Views/AudioPlayerPanel.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import HibikiShared
 
 struct AudioPlayerPanel: View {
     @EnvironmentObject var appState: AppState
@@ -196,12 +197,12 @@ struct AudioPlayerPanel: View {
                         get: { appState.playbackSpeed },
                         set: { appState.updatePlaybackSpeed($0) }
                     ),
-                    in: 1.0...2.5,
-                    step: 0.1
+                    in: PlaybackSettings.speedRange,
+                    step: PlaybackSettings.speedStep
                 )
                 .controlSize(.small)
                 
-                Text(String(format: "%.1fx", appState.playbackSpeed))
+                Text(PlaybackSettings.speedLabel(for: appState.playbackSpeed))
                     .font(.system(size: 11, weight: .medium, design: .monospaced))
                     .foregroundColor(.primary)
                     .frame(width: 36, alignment: .trailing)

--- a/Sources/Hibiki/Views/Tabs/ConfigurationTab.swift
+++ b/Sources/Hibiki/Views/Tabs/ConfigurationTab.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import AppKit
 import KeyboardShortcuts
 import HibikiPocketRuntime
+import HibikiShared
 
 struct ConfigurationTab: View {
     @EnvironmentObject var appState: AppState
@@ -431,12 +432,15 @@ struct ConfigurationTab: View {
                                 Text("Speed:")
 
                                 Slider(
-                                    value: $appState.playbackSpeed,
-                                    in: 1.0...2.5,
-                                    step: 0.1
+                                    value: Binding(
+                                        get: { appState.playbackSpeed },
+                                        set: { appState.updatePlaybackSpeed($0) }
+                                    ),
+                                    in: PlaybackSettings.speedRange,
+                                    step: PlaybackSettings.speedStep
                                 )
 
-                                Text(String(format: "%.1fx", appState.playbackSpeed))
+                                Text(PlaybackSettings.speedLabel(for: appState.playbackSpeed))
                                     .font(.system(.body, design: .monospaced))
                                     .frame(width: 45, alignment: .trailing)
                             }
@@ -444,7 +448,7 @@ struct ConfigurationTab: View {
                             HStack(spacing: 8) {
                                 ForEach([1.0, 1.5, 2.0, 2.5], id: \.self) { speed in
                                     Button(String(format: "%.1fx", speed)) {
-                                        appState.playbackSpeed = speed
+                                        appState.updatePlaybackSpeed(speed)
                                     }
                                     .buttonStyle(.bordered)
                                     .controlSize(.small)

--- a/Sources/HibikiShared/PlaybackSettings.swift
+++ b/Sources/HibikiShared/PlaybackSettings.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public enum PlaybackSettings {
+    public static let speedRange: ClosedRange<Double> = 1.0...2.5
+    public static let speedStep: Double = 0.1
+
+    public static func clampedSpeed(_ speed: Double) -> Double {
+        min(speedRange.upperBound, max(speedRange.lowerBound, speed))
+    }
+
+    public static func clampedVolume(_ volume: Double, maxVolume: Double = 3.0) -> Double {
+        min(maxVolume, max(0.0, volume))
+    }
+
+    public static func speedLabel(for speed: Double) -> String {
+        String(format: "%.1fx", clampedSpeed(speed))
+    }
+}

--- a/Tests/HibikiTests/PlaybackSettingsTests.swift
+++ b/Tests/HibikiTests/PlaybackSettingsTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+import HibikiShared
+
+final class PlaybackSettingsTests: XCTestCase {
+    func testSpeedLabelUsesSingleDecimalPlace() {
+        XCTAssertEqual(PlaybackSettings.speedLabel(for: 1.0), "1.0x")
+        XCTAssertEqual(PlaybackSettings.speedLabel(for: 2.45), "2.5x")
+    }
+
+    func testClampedSpeedKeepsValueInsideSupportedRange() {
+        XCTAssertEqual(PlaybackSettings.clampedSpeed(0.2), 1.0)
+        XCTAssertEqual(PlaybackSettings.clampedSpeed(1.7), 1.7)
+        XCTAssertEqual(PlaybackSettings.clampedSpeed(3.1), 2.5)
+    }
+
+    func testClampedVolumeKeepsValueInsideSupportedRange() {
+        XCTAssertEqual(PlaybackSettings.clampedVolume(-1.0), 0.0)
+        XCTAssertEqual(PlaybackSettings.clampedVolume(1.25), 1.25)
+        XCTAssertEqual(PlaybackSettings.clampedVolume(4.0, maxVolume: 3.0), 3.0)
+    }
+}


### PR DESCRIPTION
## Summary
- add speed and volume controls to the menu bar directly below Do Not Disturb
- share playback range, clamping, and label formatting through a small `HibikiShared` helper
- make settings-tab speed changes use the same realtime update path and add regression tests for playback settings helpers

## Why
The menu bar already exposed Do Not Disturb, but not the main playback controls. This brings speed and volume into the same surface users reach during playback.

## How to test
- run `swift build`
- run `swift test`
- launch Hibiki and open the menu bar menu
- verify `Do Not Disturb`, `Speed`, and `Volume` appear in that order above `Recent Tracks`
- verify changing speed or volume in the menu bar updates active playback immediately and persists

## Notes
- commits are split into shared playback-settings plumbing/tests and the menubar UI change
- menu layout was widened slightly so the `Volume` label is not clipped