### PR TITLE
feat: add local Voxtral TTS provider

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         ),
         .target(
             name: "HibikiPocketRuntime",
-            dependencies: [],
+            dependencies: ["HibikiShared"],
             path: "Sources/HibikiPocketRuntime"
         ),
         .executableTarget(

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 |_| |_|_|_.__/|_|_|\_\_|      |   |   |   (O)   |   |   |
 ```
 
-A macOS menu bar app that reads selected text aloud using OpenAI or ElevenLabs text-to-speech APIs. Built for agentic workflows, Hibiki supports global hotkeys, streaming audio playback, and a CLI (`hibiki --text "Hello"`) so text from editors, browsers, and terminal sessions can be spoken instantly. Agent integration is a core feature: the repo includes ready-to-use skill and hook files so coding agents can trigger speech and spoken summaries directly from workflows. Hibiki also supports optional AI summarization and translation before playback, plus history and usage tracking.
+A macOS menu bar app that reads selected text aloud using OpenAI, ElevenLabs, or self-hosted local TTS endpoints. Built for agentic workflows, Hibiki supports global hotkeys, streaming audio playback, and a CLI (`hibiki --text "Hello"`) so text from editors, browsers, and terminal sessions can be spoken instantly. Agent integration is a core feature: the repo includes ready-to-use skill and hook files so coding agents can trigger speech and spoken summaries directly from workflows. Hibiki also supports optional AI summarization and translation before playback, plus history and usage tracking.
 
 **Blog walkthrough:** [How I Built Hibiki](https://roberttlange.com/index.html#posts/blog/02-hibiki-tts.md)
 
@@ -22,7 +22,7 @@ A macOS menu bar app that reads selected text aloud using OpenAI or ElevenLabs t
 | **Agent Integration** | Built-in skill + hook templates for agent-driven spoken output |
 | **Global Hotkeys** | Option+F for TTS, Shift+Option+F for Summarize+TTS |
 | **Streaming Audio** | Audio plays as it's generated for fast response |
-| **TTS Providers** | OpenAI, ElevenLabs, or local Pocket TTS |
+| **TTS Providers** | OpenAI, ElevenLabs, local Pocket TTS, or self-hosted Mistral Voxtral |
 | **AI Summarization** | Condense long texts before reading (GPT-5 Nano/Mini/5.2) |
 | **Translation** | Translate to English, Japanese, German, French, Spanish |
 | **CLI Tool** | `hibiki --text "Hello"` or `hibiki --file-name README.md` with `--summarize` and `--translate` flags |
@@ -68,6 +68,9 @@ Set env vars through `launchctl` for GUI app visibility:
 launchctl setenv OPENAI_API_KEY "sk-..."
 launchctl setenv ELEVENLABS_API_KEY "..."
 launchctl setenv POCKET_TTS_BASE_URL "http://127.0.0.1:8000"
+launchctl setenv MISTRAL_TTS_BASE_URL "http://127.0.0.1:8091"
+launchctl setenv MISTRAL_TTS_API_KEY "optional-local-token"
+launchctl setenv MISTRAL_TTS_MODEL_ID "mistralai/Voxtral-4B-TTS-2603"
 ```
 
 Remove them later with `launchctl unsetenv <NAME>`.
@@ -87,6 +90,43 @@ Integration note: Hibiki uses a managed local Pocket TTS runtime (install/start/
 Official Pocket TTS repository: [kyutai-labs/pocket-tts](https://github.com/kyutai-labs/pocket-tts)
 
 Note: Pocket local mode is currently English-only in Hibiki.
+
+### Local Mistral Voxtral TTS
+
+Hibiki can target `mistralai/Voxtral-4B-TTS-2603` either through a manual OpenAI-compatible endpoint or a managed local runtime.
+
+Managed mode is backend-dependent:
+- On Apple Silicon macOS, Hibiki installs `mlx-audio[all]` and runs `mlx_audio.server` locally with the MLX-converted model `mlx-community/Voxtral-4B-TTS-2603-mlx-bf16`.
+- On Linux GPU hosts, Hibiki installs `vllm>=0.18.0` plus `vllm-omni` and launches `vllm serve mistralai/Voxtral-4B-TTS-2603 --omni`.
+
+#### Managed Voxtral runtime
+
+1. Open **Settings → Configuration → Local Voxtral TTS (Managed)**.
+2. Enable managed runtime.
+3. Click **Install / Reinstall**.
+4. Click **Start** (or enable auto-start).
+5. Select provider **Mistral Voxtral (Local)** in the Text to Speech section.
+
+Default managed endpoint: `http://127.0.0.1:8091`
+
+Note: Managed Voxtral on Mac requires Apple Silicon because the local path uses MLX. If managed install or launch fails on your host, Hibiki will surface the runtime error and you can still use manual endpoint mode.
+
+#### Manual Voxtral endpoint
+
+1. Start a compatible server, for example:
+
+```bash
+vllm serve mistralai/Voxtral-4B-TTS-2603 --omni
+```
+
+2. Open **Settings → Text to Speech**.
+3. Select provider **Mistral Voxtral (Local)**.
+4. Set the base URL, model ID, and voice preset if needed.
+5. Optionally set `MISTRAL_TTS_BASE_URL`, `MISTRAL_TTS_MODEL_ID`, and `MISTRAL_TTS_API_KEY` via `launchctl`.
+
+Hibiki sends requests to `/v1/audio/speech` and converts the returned WAV audio for playback.
+
+Official model card: [mistralai/Voxtral-4B-TTS-2603](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603)
 
 ## CLI Usage
 
@@ -148,6 +188,9 @@ Then merge `agents/hooks.json` into your `~/.claude/settings.json`.
 | "No OpenAI API key configured" | Add key in Settings, or run `launchctl setenv OPENAI_API_KEY "sk-..."` |
 | "No ElevenLabs API key configured" | Add key in Settings, or run `launchctl setenv ELEVENLABS_API_KEY "..."` |
 | "uv was not found" | Install `uv` and retry Pocket managed install |
+| "Managed Voxtral runtime is not supported on this Mac configuration" | Use Apple Silicon for the local MLX path, or run Voxtral on a separate Linux GPU host and use manual endpoint mode |
+| "Voxtral install failed" | Ensure the host can run `vllm` / `vllm-omni`, then retry the managed install or use manual endpoint mode |
+| "Invalid API URL" with Mistral Voxtral | Verify the base URL points at a compatible server exposing `/v1/audio/speech` |
 | Chrome not capturing text | Hibiki auto-falls back to clipboard (Cmd+C) |
 
 Debug logs available in Settings → Debug tab.
@@ -174,7 +217,7 @@ Sources/
     │   ├── TextChunker.swift        # Long text chunking
     │   └── UsageStatistics.swift    # Usage tracking
     ├── Audio/
-    │   ├── TTSService.swift         # OpenAI + ElevenLabs TTS API client
+    │   ├── TTSService.swift         # OpenAI + ElevenLabs + local Pocket/Voxtral TTS client
     │   ├── WAVStreamDecoder.swift   # Streaming WAV -> PCM decoder for local Pocket TTS
     │   ├── StreamingAudioPlayer.swift   # PCM audio playback
     │   └── AudioLevelMonitor.swift  # Audio level monitoring for waveform

--- a/Sources/Hibiki/Audio/TTSService.swift
+++ b/Sources/Hibiki/Audio/TTSService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HibikiShared
 
 enum TTSVoice: String, CaseIterable, Identifiable {
     case alloy, ash, ballad, coral, echo, fable, onyx, nova, sage, shimmer, verse
@@ -9,6 +10,7 @@ enum TTSProvider: String, CaseIterable, Identifiable {
     case openAI = "openai"
     case elevenLabs = "elevenlabs"
     case pocketLocal = "pocket-local"
+    case mistralLocal = "mistral-local"
     var id: String { rawValue }
 
     var displayName: String {
@@ -16,6 +18,7 @@ enum TTSProvider: String, CaseIterable, Identifiable {
         case .openAI: return "OpenAI"
         case .elevenLabs: return "ElevenLabs"
         case .pocketLocal: return "Pocket TTS (Local)"
+        case .mistralLocal: return "Mistral Voxtral (Local)"
         }
     }
 }
@@ -44,6 +47,10 @@ struct TTSConfiguration {
     static let defaultPocketBaseURL = "http://127.0.0.1:8000"
     static let defaultPocketVoiceURL = "alba"
     static let defaultPocketRequestTimeoutSec: Double = 60
+    static let defaultMistralLocalBaseURL = MistralLocalTTSDefaults.baseURL
+    static let defaultMistralLocalModelID = MistralLocalTTSDefaults.modelID
+    static let defaultMistralLocalVoice = MistralLocalTTSDefaults.voice
+    static let defaultMistralLocalRequestTimeoutSec = MistralLocalTTSDefaults.requestTimeoutSec
 
     let provider: TTSProvider
     let openAIAPIKey: String
@@ -54,6 +61,11 @@ struct TTSConfiguration {
     let pocketBaseURL: String
     let pocketVoiceURL: String
     let pocketRequestTimeoutSec: Double
+    let mistralLocalBaseURL: String
+    let mistralLocalAPIKey: String
+    let mistralLocalModelID: String
+    let mistralLocalVoice: String
+    let mistralLocalRequestTimeoutSec: Double
     let instructions: String
 
     var historyVoiceLabel: String {
@@ -65,6 +77,8 @@ struct TTSConfiguration {
         case .pocketLocal:
             let voice = normalizedPocketVoiceURL ?? Self.defaultPocketVoiceURL
             return "pocket:\(voice)"
+        case .mistralLocal:
+            return mistralLocalConfiguration.historyVoiceLabel
         }
     }
 
@@ -90,6 +104,34 @@ struct TTSConfiguration {
 
     var normalizedPocketRequestTimeoutSec: Double {
         max(5.0, pocketRequestTimeoutSec)
+    }
+
+    var mistralLocalConfiguration: MistralLocalTTSConfiguration {
+        MistralLocalTTSConfiguration(
+            mistralLocalBaseURL: mistralLocalBaseURL,
+            mistralLocalModelID: mistralLocalModelID,
+            mistralLocalVoice: mistralLocalVoice
+        )
+    }
+
+    var normalizedMistralLocalBaseURL: String {
+        mistralLocalConfiguration.normalizedBaseURL
+    }
+
+    var normalizedMistralLocalSpeechURL: URL? {
+        mistralLocalConfiguration.speechURL
+    }
+
+    var normalizedMistralLocalModelID: String {
+        mistralLocalConfiguration.normalizedModelID
+    }
+
+    var normalizedMistralLocalVoice: String {
+        mistralLocalConfiguration.normalizedVoice
+    }
+
+    var normalizedMistralLocalRequestTimeoutSec: Double {
+        max(5.0, mistralLocalRequestTimeoutSec)
     }
 }
 
@@ -188,6 +230,12 @@ final class TTSService: NSObject {
                 onError(TTSError.invalidURL)
                 return
             }
+        case .mistralLocal:
+            guard configuration.normalizedMistralLocalSpeechURL != nil else {
+                print("[Hibiki] ❌ Invalid Mistral Voxtral URL")
+                onError(TTSError.invalidURL)
+                return
+            }
         }
 
         // Split text into chunks for processing
@@ -256,6 +304,8 @@ final class TTSService: NSObject {
             streamSingleChunkWithElevenLabs(text: text, configuration: configuration)
         case .pocketLocal:
             streamSingleChunkWithPocketLocal(text: text, configuration: configuration)
+        case .mistralLocal:
+            streamSingleChunkWithMistralLocal(text: text, configuration: configuration)
         }
     }
 
@@ -439,6 +489,65 @@ final class TTSService: NSObject {
         currentTask?.resume()
     }
 
+    private func streamSingleChunkWithMistralLocal(text: String, configuration: TTSConfiguration) {
+        guard let url = configuration.normalizedMistralLocalSpeechURL else {
+            print("[Hibiki] ❌ Invalid Mistral Voxtral URL")
+            onError?(TTSError.invalidURL)
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("audio/wav", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = configuration.normalizedMistralLocalRequestTimeoutSec
+
+        let apiKey = configuration.mistralLocalAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        let body: [String: Any] = [
+            "input": text,
+            "model": configuration.normalizedMistralLocalModelID,
+            "voice": configuration.normalizedMistralLocalVoice,
+            "response_format": "wav"
+        ]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        } catch {
+            print("[Hibiki] ❌ JSON encoding error: \(error)")
+            onError?(error)
+            return
+        }
+
+        print("[Hibiki] 🌐 Making API request to Mistral Voxtral for chunk \(currentChunkIndex + 1)...")
+        performMistralLocalRequest(
+            request: request,
+            text: text,
+            onAudioData: { [weak self] audioData in
+                guard let self else { return }
+                self.receivedChunkCount += 1
+                self.receivedChunkBytes += audioData.count
+                self.accumulatedAudioData.append(audioData)
+                self.onAudioChunk?(audioData)
+
+                let estimatedTokens = max(1, text.count / 4)
+                self.isTokenEstimated = true
+                self.totalInputTokens += estimatedTokens
+
+                print("[Hibiki] ✅ Chunk \(self.currentChunkIndex + 1) complete, estimated tokens: \(estimatedTokens), running total: \(self.totalInputTokens)")
+
+                self.currentChunkIndex += 1
+                self.processNextChunk()
+            },
+            onError: { [weak self] error in
+                self?.onError?(error)
+            }
+        )
+    }
+
     func cancel() {
         isCancelled = true
         currentTask?.cancel()
@@ -521,6 +630,12 @@ final class TTSService: NSObject {
                 onError(TTSError.invalidURL)
                 return
             }
+        case .mistralLocal:
+            guard configuration.normalizedMistralLocalSpeechURL != nil else {
+                print("[Hibiki] ❌ Invalid Mistral Voxtral URL in pipeline")
+                onError(TTSError.invalidURL)
+                return
+            }
         }
     }
 
@@ -599,6 +714,8 @@ final class TTSService: NSObject {
             streamPipelineSentenceWithElevenLabs(text: text, configuration: configuration)
         case .pocketLocal:
             streamPipelineSentenceWithPocketLocal(text: text, configuration: configuration)
+        case .mistralLocal:
+            streamPipelineSentenceWithMistralLocal(text: text, configuration: configuration)
         }
     }
 
@@ -858,6 +975,55 @@ final class TTSService: NSObject {
         task.resume()
     }
 
+    private func streamPipelineSentenceWithMistralLocal(text: String, configuration: TTSConfiguration) {
+        guard let url = configuration.normalizedMistralLocalSpeechURL else {
+            print("[Hibiki] ❌ Invalid Mistral Voxtral URL")
+            pipelineOnError?(TTSError.invalidURL)
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("audio/wav", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = configuration.normalizedMistralLocalRequestTimeoutSec
+
+        let apiKey = configuration.mistralLocalAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        let body: [String: Any] = [
+            "input": text,
+            "model": configuration.normalizedMistralLocalModelID,
+            "voice": configuration.normalizedMistralLocalVoice,
+            "response_format": "wav"
+        ]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        } catch {
+            print("[Hibiki] ❌ JSON encoding error: \(error)")
+            pipelineOnError?(error)
+            return
+        }
+
+        performMistralLocalRequest(
+            request: request,
+            text: text,
+            onAudioData: { [weak self] audioData in
+                guard let self else { return }
+                let estimatedTokens = max(1, text.count / 4)
+                print("[Hibiki] ✅ Pipeline Mistral sentence complete: \(audioData.count) bytes, ~\(estimatedTokens) tokens")
+                self.pipelineOnAudioChunk?(audioData)
+                self.finishCurrentSentence(tokens: estimatedTokens)
+            },
+            onError: { [weak self] error in
+                self?.pipelineOnError?(error)
+            }
+        )
+    }
+
     private func configurationByUpdatingElevenLabsModel(
         _ configuration: TTSConfiguration,
         modelID: String
@@ -872,6 +1038,11 @@ final class TTSService: NSObject {
             pocketBaseURL: configuration.pocketBaseURL,
             pocketVoiceURL: configuration.pocketVoiceURL,
             pocketRequestTimeoutSec: configuration.pocketRequestTimeoutSec,
+            mistralLocalBaseURL: configuration.mistralLocalBaseURL,
+            mistralLocalAPIKey: configuration.mistralLocalAPIKey,
+            mistralLocalModelID: configuration.mistralLocalModelID,
+            mistralLocalVoice: configuration.mistralLocalVoice,
+            mistralLocalRequestTimeoutSec: configuration.mistralLocalRequestTimeoutSec,
             instructions: configuration.instructions
         )
     }
@@ -962,6 +1133,66 @@ final class TTSService: NSObject {
 
         try decoder.finalize()
         return output
+    }
+
+    private func performMistralLocalRequest(
+        request: URLRequest,
+        text: String,
+        onAudioData: @escaping (Data) -> Void,
+        onError: @escaping (Error) -> Void
+    ) {
+        let task = URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            guard let self else { return }
+
+            if self.isCancelled {
+                return
+            }
+
+            if let error {
+                if (error as NSError).code != NSURLErrorCancelled {
+                    print("[Hibiki] ❌ Mistral Voxtral error: \(error.localizedDescription)")
+                    onError(error)
+                }
+                return
+            }
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                onError(TTSError.apiError(statusCode: 0, message: nil))
+                return
+            }
+
+            guard httpResponse.statusCode == 200 else {
+                print("[Hibiki] ❌ Mistral Voxtral API error: HTTP \(httpResponse.statusCode)")
+                var parsedErrorMessage: String?
+                if let errorBody = data,
+                   let parsed = self.parseErrorMessage(from: errorBody) {
+                    parsedErrorMessage = parsed
+                }
+                onError(TTSError.apiError(statusCode: httpResponse.statusCode, message: parsedErrorMessage))
+                return
+            }
+
+            guard let wavData = data, !wavData.isEmpty else {
+                print("[Hibiki] ⚠️ Mistral Voxtral returned empty data")
+                onError(TTSError.emptyAudioData)
+                return
+            }
+
+            do {
+                let pcmData = try self.decodePocketWAVResponseData(wavData)
+                guard !pcmData.isEmpty else {
+                    onError(TTSError.emptyAudioData)
+                    return
+                }
+                onAudioData(pcmData)
+            } catch {
+                print("[Hibiki] ❌ Mistral Voxtral decode failed for \(text.count) chars: \(error.localizedDescription)")
+                onError(error)
+            }
+        }
+
+        currentTask = task
+        task.resume()
     }
 
     /// Mark current sentence as complete and process next
@@ -1199,6 +1430,8 @@ enum TTSError: Error, LocalizedError {
                 return "ElevenLabs API key is not configured"
             case .pocketLocal:
                 return "Pocket TTS local runtime is not configured"
+            case .mistralLocal:
+                return "Mistral Voxtral local endpoint is not configured"
             }
         case .missingVoiceID(let provider):
             switch provider {
@@ -1208,6 +1441,8 @@ enum TTSError: Error, LocalizedError {
                 return "ElevenLabs voice ID is not configured"
             case .pocketLocal:
                 return "Pocket TTS voice is not configured"
+            case .mistralLocal:
+                return "Mistral Voxtral voice is not configured"
             }
         case .invalidConfiguration:
             return "Invalid TTS configuration"

--- a/Sources/Hibiki/Core/AppState.swift
+++ b/Sources/Hibiki/Core/AppState.swift
@@ -91,6 +91,17 @@ final class AppState: ObservableObject {
     @AppStorage("pocketBaseURL") var pocketBaseURL: String = TTSConfiguration.defaultPocketBaseURL
     @AppStorage("pocketVoiceURL") var pocketVoiceURL: String = TTSConfiguration.defaultPocketVoiceURL
     @AppStorage("pocketRequestTimeoutSec") var pocketRequestTimeoutSec: Double = TTSConfiguration.defaultPocketRequestTimeoutSec
+    @AppStorage("mistralLocalBaseURL") var mistralLocalBaseURL: String = TTSConfiguration.defaultMistralLocalBaseURL
+    @AppStorage("mistralLocalAPIKey") var mistralLocalAPIKey: String = ""
+    @AppStorage("mistralLocalModelID") var mistralLocalModelID: String = TTSConfiguration.defaultMistralLocalModelID
+    @AppStorage("mistralLocalVoice") var mistralLocalVoice: String = TTSConfiguration.defaultMistralLocalVoice
+    @AppStorage("mistralLocalRequestTimeoutSec") var mistralLocalRequestTimeoutSec: Double = TTSConfiguration.defaultMistralLocalRequestTimeoutSec
+    @AppStorage("mistralManagedEnabled") var mistralManagedEnabled: Bool = false
+    @AppStorage("mistralManagedAutoStart") var mistralManagedAutoStart: Bool = true
+    @AppStorage("mistralManagedHost") var mistralManagedHost: String = "127.0.0.1"
+    @AppStorage("mistralManagedPort") var mistralManagedPort: Int = 8091
+    @AppStorage("mistralManagedVenvPath") var mistralManagedVenvPath: String = VoxtralRuntimeManager.defaultVenvPath()
+    @AppStorage("mistralManagedLastError") var mistralManagedLastError: String = ""
     @AppStorage("pocketManagedEnabled") var pocketManagedEnabled: Bool = false
     @AppStorage("pocketManagedAutoStart") var pocketManagedAutoStart: Bool = true
     @AppStorage("pocketManagedHost") var pocketManagedHost: String = "127.0.0.1"
@@ -169,6 +180,7 @@ final class AppState: ObservableObject {
     private let audioPlayer = StreamingAudioPlayer.shared
     private let accessibilityManager = AccessibilityManager.shared
     let pocketRuntimeManager = PocketTTSRuntimeManager.shared
+    let voxtralRuntimeManager = VoxtralRuntimeManager.shared
     private var summarizationTask: Task<Void, Never>?
     private var translationTask: Task<Void, Never>?
     private let interleavedPipeline = InterleavedPipeline()
@@ -368,13 +380,31 @@ final class AppState: ObservableObject {
             elevenLabsAPIKey = envKey
             logger.info("Loaded ElevenLabs API key from ELEVENLABS_API_KEY via \(source.rawValue)", source: "AppState")
         }
+        if let (envKey, source) = resolvedEnvironmentValue(for: "MISTRAL_TTS_API_KEY", logSource: "AppState"),
+           mistralLocalAPIKey != envKey {
+            mistralLocalAPIKey = envKey
+            logger.info("Loaded Mistral TTS API key from MISTRAL_TTS_API_KEY via \(source.rawValue)", source: "AppState")
+        }
         if pocketBaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
            let (envBaseURL, source) = resolvedEnvironmentValue(for: "POCKET_TTS_BASE_URL", logSource: "AppState") {
             pocketBaseURL = envBaseURL
             logger.info("Loaded Pocket TTS base URL from POCKET_TTS_BASE_URL via \(source.rawValue)", source: "AppState")
         }
+        if mistralLocalBaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           let (envBaseURL, source) = resolvedEnvironmentValue(for: "MISTRAL_TTS_BASE_URL", logSource: "AppState") {
+            mistralLocalBaseURL = envBaseURL
+            logger.info("Loaded Mistral TTS base URL from MISTRAL_TTS_BASE_URL via \(source.rawValue)", source: "AppState")
+        }
+        if let (envModelID, source) = resolvedEnvironmentValue(for: "MISTRAL_TTS_MODEL_ID", logSource: "AppState"),
+           mistralLocalModelID != envModelID {
+            mistralLocalModelID = envModelID
+            logger.info("Loaded Mistral TTS model ID from MISTRAL_TTS_MODEL_ID via \(source.rawValue)", source: "AppState")
+        }
         if pocketManagedVenvPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             pocketManagedVenvPath = PocketTTSRuntimeManager.defaultVenvPath()
+        }
+        if mistralManagedVenvPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            mistralManagedVenvPath = VoxtralRuntimeManager.defaultVenvPath()
         }
         let clampedSpeed = PlaybackSettings.clampedSpeed(playbackSpeed)
         if clampedSpeed != playbackSpeed {
@@ -395,6 +425,13 @@ final class AppState: ObservableObject {
            activeTTSProvider() == .pocketLocal {
             Task { @MainActor [weak self] in
                 await self?.ensurePocketRuntimeStarted(logSource: "AppState")
+            }
+        }
+        if mistralManagedModeEnabled,
+           mistralManagedAutoStart,
+           activeTTSProvider() == .mistralLocal {
+            Task { @MainActor [weak self] in
+                await self?.ensureMistralRuntimeStarted(logSource: "AppState")
             }
         }
     }
@@ -510,8 +547,73 @@ final class AppState: ObservableObject {
         return nil
     }
 
+    private func resolveMistralLocalAPIKey(logSource: String) -> String {
+        if let (envKey, source) = resolvedEnvironmentValue(for: "MISTRAL_TTS_API_KEY", logSource: logSource) {
+            if mistralLocalAPIKey != envKey {
+                mistralLocalAPIKey = envKey
+                logger.info("Loaded Mistral TTS API key from MISTRAL_TTS_API_KEY via \(source.rawValue)", source: logSource)
+            }
+            return envKey
+        }
+
+        return normalizedEnvironmentValue(mistralLocalAPIKey) ?? ""
+    }
+
+    private func resolveMistralLocalBaseURL(logSource: String) -> String {
+        if mistralManagedModeEnabled {
+            return managedMistralBaseURL()
+        }
+
+        let configuredBaseURL = mistralLocalBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !configuredBaseURL.isEmpty {
+            return configuredBaseURL
+        }
+
+        if let (envURL, source) = resolvedEnvironmentValue(for: "MISTRAL_TTS_BASE_URL", logSource: logSource) {
+            mistralLocalBaseURL = envURL
+            logger.info("Loaded Mistral TTS base URL from MISTRAL_TTS_BASE_URL via \(source.rawValue)", source: logSource)
+            return envURL
+        }
+
+        return TTSConfiguration.defaultMistralLocalBaseURL
+    }
+
+    private func resolveMistralLocalModelID(logSource: String) -> String {
+        let configuredModelID = mistralLocalModelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !configuredModelID.isEmpty {
+            if mistralManagedModeEnabled,
+               VoxtralRuntimeManager.backendKind == .mlxAudioAppleSilicon,
+               configuredModelID == TTSConfiguration.defaultMistralLocalModelID {
+                mistralLocalModelID = VoxtralRuntimeManager.defaultManagedModelID
+                logger.info("Migrated managed Voxtral model ID to Apple Silicon MLX variant", source: logSource)
+                return VoxtralRuntimeManager.defaultManagedModelID
+            }
+            return configuredModelID
+        }
+
+        if let (envModelID, source) = resolvedEnvironmentValue(for: "MISTRAL_TTS_MODEL_ID", logSource: logSource) {
+            mistralLocalModelID = envModelID
+            logger.info("Loaded Mistral TTS model ID from MISTRAL_TTS_MODEL_ID via \(source.rawValue)", source: logSource)
+            return envModelID
+        }
+
+        if mistralManagedModeEnabled {
+            return VoxtralRuntimeManager.defaultManagedModelID
+        }
+
+        return TTSConfiguration.defaultMistralLocalModelID
+    }
+
     private func managedPocketBaseURL() -> String {
         PocketTTSRuntimeManager.baseURL(host: pocketManagedHost, port: pocketManagedPort)
+    }
+
+    private func managedMistralBaseURL() -> String {
+        VoxtralRuntimeManager.baseURL(host: mistralManagedHost, port: mistralManagedPort)
+    }
+
+    private var mistralManagedModeEnabled: Bool {
+        mistralManagedEnabled && VoxtralRuntimeManager.isManagedRuntimeSupportedOnCurrentPlatform
     }
 
     private func effectivePocketVoice() -> String {
@@ -564,6 +666,11 @@ final class AppState: ObservableObject {
                 pocketBaseURL: pocketBaseURL,
                 pocketVoiceURL: pocketVoiceURL,
                 pocketRequestTimeoutSec: pocketRequestTimeoutSec,
+                mistralLocalBaseURL: mistralLocalBaseURL,
+                mistralLocalAPIKey: mistralLocalAPIKey,
+                mistralLocalModelID: mistralLocalModelID,
+                mistralLocalVoice: mistralLocalVoice,
+                mistralLocalRequestTimeoutSec: mistralLocalRequestTimeoutSec,
                 instructions: TTSConfiguration.defaultInstructions
             )
 
@@ -591,6 +698,11 @@ final class AppState: ObservableObject {
                 pocketBaseURL: pocketBaseURL,
                 pocketVoiceURL: pocketVoiceURL,
                 pocketRequestTimeoutSec: pocketRequestTimeoutSec,
+                mistralLocalBaseURL: mistralLocalBaseURL,
+                mistralLocalAPIKey: mistralLocalAPIKey,
+                mistralLocalModelID: mistralLocalModelID,
+                mistralLocalVoice: mistralLocalVoice,
+                mistralLocalRequestTimeoutSec: mistralLocalRequestTimeoutSec,
                 instructions: TTSConfiguration.defaultInstructions
             )
 
@@ -611,6 +723,30 @@ final class AppState: ObservableObject {
                 pocketBaseURL: baseURL,
                 pocketVoiceURL: effectivePocketVoice(),
                 pocketRequestTimeoutSec: pocketRequestTimeoutSec,
+                mistralLocalBaseURL: mistralLocalBaseURL,
+                mistralLocalAPIKey: mistralLocalAPIKey,
+                mistralLocalModelID: mistralLocalModelID,
+                mistralLocalVoice: mistralLocalVoice,
+                mistralLocalRequestTimeoutSec: mistralLocalRequestTimeoutSec,
+                instructions: TTSConfiguration.defaultInstructions
+            )
+
+        case .mistralLocal:
+            return TTSConfiguration(
+                provider: .mistralLocal,
+                openAIAPIKey: openAIAPIKeyOverride ?? "",
+                openAIVoice: openAIVoice,
+                elevenLabsAPIKey: "",
+                elevenLabsVoiceID: "",
+                elevenLabsModelID: elevenLabsModelID,
+                pocketBaseURL: pocketBaseURL,
+                pocketVoiceURL: pocketVoiceURL,
+                pocketRequestTimeoutSec: pocketRequestTimeoutSec,
+                mistralLocalBaseURL: resolveMistralLocalBaseURL(logSource: logSource),
+                mistralLocalAPIKey: resolveMistralLocalAPIKey(logSource: logSource),
+                mistralLocalModelID: resolveMistralLocalModelID(logSource: logSource),
+                mistralLocalVoice: mistralLocalVoice,
+                mistralLocalRequestTimeoutSec: mistralLocalRequestTimeoutSec,
                 instructions: TTSConfiguration.defaultInstructions
             )
         }
@@ -683,6 +819,11 @@ final class AppState: ObservableObject {
             pocketBaseURL: baseURL,
             pocketVoiceURL: effectivePocketVoice(),
             pocketRequestTimeoutSec: pocketRequestTimeoutSec,
+            mistralLocalBaseURL: mistralLocalBaseURL,
+            mistralLocalAPIKey: mistralLocalAPIKey,
+            mistralLocalModelID: mistralLocalModelID,
+            mistralLocalVoice: mistralLocalVoice,
+            mistralLocalRequestTimeoutSec: mistralLocalRequestTimeoutSec,
             instructions: TTSConfiguration.defaultInstructions
         )
 
@@ -699,13 +840,103 @@ final class AppState: ObservableObject {
     }
 
     @MainActor
+    func installMistralRuntime() async {
+        do {
+            try await voxtralRuntimeManager.reinstall(venvPath: mistralManagedVenvPath)
+            mistralManagedLastError = ""
+            errorMessage = nil
+        } catch {
+            mistralManagedLastError = error.localizedDescription
+            errorMessage = error.localizedDescription
+            logger.error("Voxtral runtime install failed: \(error.localizedDescription)", source: "AppState")
+        }
+    }
+
+    @MainActor
+    func startMistralRuntime() async {
+        await ensureMistralRuntimeStarted(logSource: "Settings")
+    }
+
+    @MainActor
+    func stopMistralRuntime() {
+        voxtralRuntimeManager.stopServer()
+    }
+
+    @MainActor
+    func restartMistralRuntime() async {
+        do {
+            try await voxtralRuntimeManager.restartServer(
+                host: mistralManagedHost,
+                port: mistralManagedPort,
+                modelID: resolveMistralLocalModelID(logSource: "Settings"),
+                apiKey: resolveMistralLocalAPIKey(logSource: "Settings"),
+                venvPath: mistralManagedVenvPath,
+                autoRestart: mistralManagedAutoStart
+            )
+            mistralManagedLastError = ""
+            errorMessage = nil
+        } catch {
+            mistralManagedLastError = error.localizedDescription
+            errorMessage = error.localizedDescription
+            logger.error("Voxtral runtime restart failed: \(error.localizedDescription)", source: "Settings")
+        }
+    }
+
+    @MainActor
+    func runMistralRuntimeHealthCheck() async -> VoxtralRuntimeHealth {
+        let baseURL = mistralManagedModeEnabled ? managedMistralBaseURL() : mistralLocalBaseURL
+        return await voxtralRuntimeManager.healthCheck(
+            baseURL: baseURL,
+            apiKey: resolveMistralLocalAPIKey(logSource: "Settings")
+        )
+    }
+
+    @MainActor
+    func runMistralRuntimeHealthCheckWithReadout() async {
+        let health = await runMistralRuntimeHealthCheck()
+        guard health.isHealthy else {
+            errorMessage = health.message ?? "Voxtral health check failed."
+            return
+        }
+
+        let healthCheckConfiguration = TTSConfiguration(
+            provider: .mistralLocal,
+            openAIAPIKey: "",
+            openAIVoice: TTSVoice(rawValue: selectedVoice) ?? .coral,
+            elevenLabsAPIKey: "",
+            elevenLabsVoiceID: "",
+            elevenLabsModelID: elevenLabsModelID,
+            pocketBaseURL: pocketBaseURL,
+            pocketVoiceURL: pocketVoiceURL,
+            pocketRequestTimeoutSec: pocketRequestTimeoutSec,
+            mistralLocalBaseURL: resolveMistralLocalBaseURL(logSource: "Settings"),
+            mistralLocalAPIKey: resolveMistralLocalAPIKey(logSource: "Settings"),
+            mistralLocalModelID: resolveMistralLocalModelID(logSource: "Settings"),
+            mistralLocalVoice: mistralLocalVoice,
+            mistralLocalRequestTimeoutSec: mistralLocalRequestTimeoutSec,
+            instructions: TTSConfiguration.defaultInstructions
+        )
+
+        errorMessage = nil
+        enqueueRequest(
+            source: .settings,
+            text: "Mistral Voxtral health check successful.",
+            shouldSummarize: false,
+            targetLanguage: nil,
+            summarizationPromptOverride: nil,
+            ttsConfigurationOverride: healthCheckConfiguration
+        )
+        processNextRequestIfPossible()
+    }
+
+    @MainActor
     private func ensurePocketRuntimeStarted(logSource: String) async {
         guard pocketManagedEnabled else { return }
 
         do {
             try await pocketRuntimeManager.installIfNeeded(venvPath: pocketManagedVenvPath)
 
-            let portsToTry = candidateManagedPocketPorts(startingAt: pocketManagedPort)
+            let portsToTry = candidateManagedPorts(startingAt: pocketManagedPort)
             var started = false
             var lastStartupError: Error?
 
@@ -764,7 +995,82 @@ final class AppState: ObservableObject {
         }
     }
 
-    private func candidateManagedPocketPorts(startingAt startPort: Int) -> [Int] {
+    @MainActor
+    private func ensureMistralRuntimeStarted(logSource: String) async {
+        guard mistralManagedEnabled else { return }
+        guard VoxtralRuntimeManager.isManagedRuntimeSupportedOnCurrentPlatform else {
+            let message = VoxtralRuntimeError.unsupportedPlatform(VoxtralRuntimeManager.unsupportedPlatformDescription).localizedDescription
+            mistralManagedLastError = message
+            errorMessage = message
+            logger.error("Voxtral managed runtime unsupported on this platform", source: logSource)
+            return
+        }
+
+        do {
+            try await voxtralRuntimeManager.installIfNeeded(venvPath: mistralManagedVenvPath)
+
+            let portsToTry = candidateManagedPorts(startingAt: mistralManagedPort)
+            var started = false
+            var lastStartupError: Error?
+            let apiKey = resolveMistralLocalAPIKey(logSource: logSource)
+            let modelID = resolveMistralLocalModelID(logSource: logSource)
+
+            for port in portsToTry {
+                let baseURL = VoxtralRuntimeManager.baseURL(host: mistralManagedHost, port: port)
+                let health = await voxtralRuntimeManager.healthCheck(baseURL: baseURL, apiKey: apiKey)
+                if health.isHealthy {
+                    if mistralManagedPort != port {
+                        logger.warning("Switching Voxtral managed port to \(port) because configured port is unavailable", source: logSource)
+                        mistralManagedPort = port
+                    }
+                    started = true
+                    break
+                }
+
+                if health.statusCode != nil, !health.isVoxtralAPI {
+                    logger.warning("Port \(port) is occupied by a non-Voxtral service, skipping.", source: logSource)
+                    continue
+                }
+
+                do {
+                    try await voxtralRuntimeManager.startServer(
+                        host: mistralManagedHost,
+                        port: port,
+                        modelID: modelID,
+                        apiKey: apiKey,
+                        venvPath: mistralManagedVenvPath,
+                        autoRestart: mistralManagedAutoStart
+                    )
+                    let postStartHealth = await voxtralRuntimeManager.healthCheck(baseURL: baseURL, apiKey: apiKey)
+                    if postStartHealth.isHealthy {
+                        if mistralManagedPort != port {
+                            logger.warning("Using fallback Voxtral managed port \(port)", source: logSource)
+                            mistralManagedPort = port
+                        }
+                        started = true
+                        break
+                    }
+                } catch {
+                    lastStartupError = error
+                }
+            }
+
+            guard started else {
+                if let lastStartupError {
+                    throw lastStartupError
+                }
+                throw VoxtralRuntimeError.healthCheckFailed
+            }
+
+            mistralManagedLastError = ""
+        } catch {
+            mistralManagedLastError = error.localizedDescription
+            errorMessage = error.localizedDescription
+            logger.error("Voxtral runtime startup failed: \(error.localizedDescription)", source: logSource)
+        }
+    }
+
+    private func candidateManagedPorts(startingAt startPort: Int) -> [Int] {
         let safeStart = max(1025, min(65500, startPort))
         var ports: [Int] = [safeStart]
         for offset in 1...5 {
@@ -1330,6 +1636,24 @@ final class AppState: ObservableObject {
             }
         }
 
+        if provider == .mistralLocal, !mistralManagedModeEnabled {
+            let configuredBaseURL = resolveMistralLocalBaseURL(logSource: logSource)
+            let manualHealth = await voxtralRuntimeManager.healthCheck(
+                baseURL: configuredBaseURL,
+                apiKey: resolveMistralLocalAPIKey(logSource: logSource)
+            )
+            if manualHealth.isHealthy {
+                mistralLocalBaseURL = configuredBaseURL
+            } else if !manualHealth.isVoxtralAPI,
+                      voxtralRuntimeManager.hasInstalledRuntime(venvPath: mistralManagedVenvPath) {
+                logger.warning(
+                    "Configured Voxtral endpoint is not Voxtral API (\(configuredBaseURL)); switching to managed runtime.",
+                    source: logSource
+                )
+                mistralManagedEnabled = true
+            }
+        }
+
         let openAIAPIKey: String?
         if requiresOpenAIForLLM || provider == .openAI {
             guard let resolved = resolveOpenAIAPIKey(logSource: logSource) else {
@@ -1346,6 +1670,14 @@ final class AppState: ObservableObject {
         if provider == .pocketLocal, pocketManagedEnabled {
             await ensurePocketRuntimeStarted(logSource: logSource)
             if !pocketManagedLastError.isEmpty {
+                markRequestFinished()
+                return
+            }
+        }
+
+        if provider == .mistralLocal, mistralManagedModeEnabled {
+            await ensureMistralRuntimeStarted(logSource: logSource)
+            if !mistralManagedLastError.isEmpty {
                 markRequestFinished()
                 return
             }

--- a/Sources/Hibiki/Core/HistoryEntry.swift
+++ b/Sources/Hibiki/Core/HistoryEntry.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HibikiShared
 
 struct HistoryEntry: Identifiable, Codable, Sendable {
     let id: UUID
@@ -69,7 +70,7 @@ struct HistoryEntry: Identifiable, Codable, Sendable {
         self.targetLanguage = targetLanguage
 
         // Local providers are free from API billing perspective.
-        if voice.hasPrefix("pocket:") {
+        if LocalTTSVoiceLabel.isLocal(voice) {
             self.ttsCost = 0
         } else {
             self.ttsCost = TTSPricing.calculateCost(inputTokens: inputTokens)
@@ -134,8 +135,11 @@ struct HistoryEntry: Identifiable, Codable, Sendable {
         if voice.hasPrefix("elevenlabs:") {
             return .elevenLabs
         }
-        if voice.hasPrefix("pocket:") {
+        if LocalTTSVoiceLabel.isPocket(voice) {
             return .pocketLocal
+        }
+        if LocalTTSVoiceLabel.isMistral(voice) {
+            return .mistralLocal
         }
         return .openAI
     }

--- a/Sources/Hibiki/Views/AudioPlayerPanel.swift
+++ b/Sources/Hibiki/Views/AudioPlayerPanel.swift
@@ -322,6 +322,8 @@ struct AudioPlayerPanel: View {
         switch provider {
         case .pocketLocal:
             return "Pocket TTS"
+        case .mistralLocal:
+            return "Mistral Voxtral"
         default:
             return provider.displayName
         }

--- a/Sources/Hibiki/Views/HistoryTableView.swift
+++ b/Sources/Hibiki/Views/HistoryTableView.swift
@@ -252,6 +252,8 @@ struct HistoryTableView: View {
             return Color(red: 0.3, green: 0.55, blue: 0.85)
         case .pocketLocal:
             return .orange
+        case .mistralLocal:
+            return Color(red: 0.55, green: 0.35, blue: 0.15)
         }
     }
 }

--- a/Sources/Hibiki/Views/Tabs/ConfigurationTab.swift
+++ b/Sources/Hibiki/Views/Tabs/ConfigurationTab.swift
@@ -9,6 +9,7 @@ struct ConfigurationTab: View {
     @StateObject private var pocketRuntimeManager = PocketTTSRuntimeManager.shared
     @State private var showOpenAIKey = false
     @State private var showElevenLabsKey = false
+    @State private var showMistralLocalKey = false
     @State private var hasAccessibility = false
     @State private var cliInstallStatus: CLIInstallStatus = .unknown
     @State private var isInstallingCLI = false
@@ -224,7 +225,7 @@ struct ConfigurationTab: View {
                                 .frame(maxWidth: .infinity, alignment: .topLeading)
                             }
 
-                            Text("Env vars: OPENAI_API_KEY, ELEVENLABS_API_KEY, POCKET_TTS_BASE_URL")
+                            Text("Env vars: OPENAI_API_KEY, ELEVENLABS_API_KEY, POCKET_TTS_BASE_URL, MISTRAL_TTS_BASE_URL, MISTRAL_TTS_API_KEY, MISTRAL_TTS_MODEL_ID")
                                 .font(.caption2)
                                 .foregroundColor(.secondary)
 
@@ -375,7 +376,7 @@ struct ConfigurationTab: View {
                                 Text("Voice ID is configurable in API Keys.")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
-                            } else {
+                            } else if selectedTTSProvider == .pocketLocal {
                                 VStack(alignment: .leading, spacing: 6) {
                                     if !appState.pocketManagedEnabled {
                                         Text("Endpoint URL:")
@@ -410,6 +411,73 @@ struct ConfigurationTab: View {
                                 }
 
                                 Text("Pocket TTS local mode is English-only in this release.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            } else {
+                                VStack(alignment: .leading, spacing: 6) {
+                                    if !appState.mistralManagedEnabled {
+                                        Text("Endpoint URL:")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                        TextField("http://127.0.0.1:8091", text: $appState.mistralLocalBaseURL)
+                                            .textFieldStyle(.roundedBorder)
+                                    } else {
+                                        Text("Managed runtime controls host and port below.")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                    }
+
+                                    Text("Model ID:")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                    TextField(
+                                        appState.mistralManagedEnabled
+                                            ? VoxtralRuntimeManager.defaultManagedModelID
+                                            : TTSConfiguration.defaultMistralLocalModelID,
+                                        text: $appState.mistralLocalModelID
+                                    )
+                                    .textFieldStyle(.roundedBorder)
+
+                                    Text("Voice preset:")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                    TextField(
+                                        TTSConfiguration.defaultMistralLocalVoice,
+                                        text: $appState.mistralLocalVoice
+                                    )
+                                    .textFieldStyle(.roundedBorder)
+
+                                    Text("Optional API key:")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                    HStack {
+                                        if showMistralLocalKey {
+                                            TextField("token-...", text: $appState.mistralLocalAPIKey)
+                                                .textFieldStyle(.roundedBorder)
+                                        } else {
+                                            SecureField("token-...", text: $appState.mistralLocalAPIKey)
+                                                .textFieldStyle(.roundedBorder)
+                                        }
+                                        Button(showMistralLocalKey ? "Hide" : "Show") {
+                                            showMistralLocalKey.toggle()
+                                        }
+                                    }
+
+                                    HStack(spacing: 8) {
+                                        Text("Timeout (s):")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                        TextField(
+                                            "180",
+                                            value: $appState.mistralLocalRequestTimeoutSec,
+                                            format: .number.precision(.fractionLength(0...1))
+                                        )
+                                        .textFieldStyle(.roundedBorder)
+                                        .frame(width: 80)
+                                    }
+                                }
+
+                                Text("Targets an OpenAI-compatible `/v1/audio/speech` endpoint, e.g. `vllm serve mistralai/Voxtral-4B-TTS-2603 --omni` or `mlx_audio.server`.")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                             }
@@ -630,6 +698,8 @@ struct ConfigurationTab: View {
                     }
                     .padding(.vertical, 4)
                 }
+
+                VoxtralManagedRuntimeSection()
 
                 GroupBox("History Retention") {
                     VStack(alignment: .leading, spacing: 10) {

--- a/Sources/Hibiki/Views/Tabs/VoxtralManagedRuntimeSection.swift
+++ b/Sources/Hibiki/Views/Tabs/VoxtralManagedRuntimeSection.swift
@@ -1,0 +1,200 @@
+import SwiftUI
+import HibikiPocketRuntime
+
+struct VoxtralManagedRuntimeSection: View {
+    @EnvironmentObject var appState: AppState
+    @StateObject private var voxtralRuntimeManager = VoxtralRuntimeManager.shared
+    @State private var isInstallingRuntime = false
+    @State private var isStartingRuntime = false
+    @State private var isRestartingRuntime = false
+
+    private var managedRuntimeSupported: Bool {
+        VoxtralRuntimeManager.isManagedRuntimeSupportedOnCurrentPlatform
+    }
+
+    private var unsupportedRuntimeMessage: String {
+        VoxtralRuntimeError
+            .unsupportedPlatform(VoxtralRuntimeManager.unsupportedPlatformDescription)
+            .localizedDescription
+    }
+
+    private var backendSummary: String {
+        switch VoxtralRuntimeManager.backendKind {
+        case .vllmOmniLinux:
+            return "Backend: vLLM Omni on Linux GPU."
+        case .mlxAudioAppleSilicon:
+            return "Backend: MLX-Audio on Apple Silicon."
+        case .unsupported:
+            return "Backend unavailable on this platform."
+        }
+    }
+
+    private var statusIcon: String {
+        switch voxtralRuntimeManager.status {
+        case .running:
+            return "checkmark.circle.fill"
+        case .installing, .starting:
+            return "arrow.triangle.2.circlepath.circle.fill"
+        case .unhealthy, .failed:
+            return "xmark.circle.fill"
+        case .installed, .stopped:
+            return "pause.circle.fill"
+        case .notInstalled:
+            return "xmark.circle.fill"
+        }
+    }
+
+    private var statusColor: Color {
+        switch voxtralRuntimeManager.status {
+        case .running:
+            return .green
+        case .installing, .starting:
+            return .orange
+        case .installed, .stopped:
+            return .secondary
+        case .unhealthy, .failed, .notInstalled:
+            return .red
+        }
+    }
+
+    var body: some View {
+        GroupBox("Local Voxtral TTS (Managed)") {
+            VStack(alignment: .leading, spacing: 10) {
+                Toggle("Enable managed runtime", isOn: $appState.mistralManagedEnabled)
+                Toggle("Auto-start with Hibiki", isOn: $appState.mistralManagedAutoStart)
+
+                HStack(spacing: 12) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Host")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        TextField("127.0.0.1", text: $appState.mistralManagedHost)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 140)
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Port")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        TextField("8091", value: $appState.mistralManagedPort, format: .number)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 90)
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Model")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text(appState.mistralLocalModelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                             ? TTSConfiguration.defaultMistralLocalModelID
+                             : appState.mistralLocalModelID)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundColor(.secondary)
+                            .lineLimit(2)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Managed venv path")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    TextField("", text: $appState.mistralManagedVenvPath)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                Text("Uses the Voxtral provider settings above for model ID, API key, voice preset, and request timeout.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Text(backendSummary)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                if !managedRuntimeSupported {
+                    Text(unsupportedRuntimeMessage)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+
+                HStack(spacing: 8) {
+                    Image(systemName: statusIcon)
+                        .foregroundColor(statusColor)
+                    Text(voxtralRuntimeManager.status.displayName)
+                        .font(.system(.caption, design: .monospaced))
+                    Text("v\(voxtralRuntimeManager.installedVersion)")
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    if let date = voxtralRuntimeManager.lastHealthCheckAt {
+                        Text("health \(date.formatted(date: .omitted, time: .standard))")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                HStack(spacing: 8) {
+                    Button("Install / Reinstall") {
+                        Task {
+                            isInstallingRuntime = true
+                            await appState.installMistralRuntime()
+                            isInstallingRuntime = false
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!managedRuntimeSupported || isInstallingRuntime || isStartingRuntime || isRestartingRuntime)
+
+                    Button("Start") {
+                        Task {
+                            isStartingRuntime = true
+                            await appState.startMistralRuntime()
+                            isStartingRuntime = false
+                        }
+                    }
+                    .disabled(!managedRuntimeSupported || isInstallingRuntime || isStartingRuntime || isRestartingRuntime)
+
+                    Button("Stop") {
+                        appState.stopMistralRuntime()
+                    }
+                    .disabled(!managedRuntimeSupported || isInstallingRuntime || isStartingRuntime || isRestartingRuntime)
+
+                    Button("Restart") {
+                        Task {
+                            isRestartingRuntime = true
+                            await appState.restartMistralRuntime()
+                            isRestartingRuntime = false
+                        }
+                    }
+                    .disabled(!managedRuntimeSupported || isInstallingRuntime || isStartingRuntime || isRestartingRuntime)
+
+                    Button("Health Check") {
+                        Task {
+                            await appState.runMistralRuntimeHealthCheckWithReadout()
+                        }
+                    }
+                    .disabled(!managedRuntimeSupported || isInstallingRuntime || isStartingRuntime || isRestartingRuntime)
+
+                    if isInstallingRuntime || isStartingRuntime || isRestartingRuntime {
+                        ProgressView()
+                            .scaleEffect(0.7)
+                    }
+                }
+
+                if !appState.mistralManagedLastError.isEmpty {
+                    Text(appState.mistralManagedLastError)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+
+                if !voxtralRuntimeManager.recentLogs.isEmpty {
+                    Text(voxtralRuntimeManager.recentLogs.suffix(4).joined(separator: "\n"))
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+}

--- a/Sources/HibikiPocketRuntime/VoxtralRuntimeManager.swift
+++ b/Sources/HibikiPocketRuntime/VoxtralRuntimeManager.swift
@@ -50,13 +50,13 @@ public final class VoxtralRuntimeManager: ObservableObject {
     private var launchConfig: ServerLaunchConfig?
 
     public static var backendKind: BackendKind {
-#if os(Linux)
-        .vllmOmniLinux
-#elseif os(macOS) && arch(arm64)
-        .mlxAudioAppleSilicon
-#else
-        .unsupported
-#endif
+        if isLinux {
+            return .vllmOmniLinux
+        }
+        if isAppleSiliconMac {
+            return .mlxAudioAppleSilicon
+        }
+        return .unsupported
     }
 
     public static var isManagedRuntimeSupportedOnCurrentPlatform: Bool {
@@ -64,13 +64,13 @@ public final class VoxtralRuntimeManager: ObservableObject {
     }
 
     public static var unsupportedPlatformDescription: String {
-#if os(macOS)
-        "this Mac configuration"
-#elseif os(Linux)
-        "Linux"
-#else
-        "this platform"
-#endif
+        if isLinux {
+            return "Linux"
+        }
+        if isMacOS {
+            return "this Mac configuration"
+        }
+        return "this platform"
     }
 
     public static var backendDisplayName: String {
@@ -108,6 +108,37 @@ public final class VoxtralRuntimeManager: ObservableObject {
 
     public var isRunning: Bool {
         serverProcess?.isRunning == true && status == .running
+    }
+
+    private static var isLinux: Bool {
+#if os(Linux)
+        true
+#else
+        false
+#endif
+    }
+
+    private static var isMacOS: Bool {
+#if os(macOS)
+        true
+#else
+        false
+#endif
+    }
+
+    private static var isAppleSiliconMac: Bool {
+#if os(macOS)
+        return sysctlFlag(named: "hw.optional.arm64") == 1
+#else
+        return false
+#endif
+    }
+
+    private static func sysctlFlag(named name: String) -> Int32 {
+        var value: Int32 = 0
+        var size = MemoryLayout<Int32>.size
+        let result = sysctlbyname(name, &value, &size, nil, 0)
+        return result == 0 ? value : 0
     }
 
     public func hasInstalledRuntime(venvPath: String? = nil) -> Bool {

--- a/Sources/HibikiPocketRuntime/VoxtralRuntimeManager.swift
+++ b/Sources/HibikiPocketRuntime/VoxtralRuntimeManager.swift
@@ -1,0 +1,874 @@
+import Foundation
+import Combine
+import HibikiShared
+
+public final class VoxtralRuntimeManager: ObservableObject {
+    public enum BackendKind {
+        case vllmOmniLinux
+        case mlxAudioAppleSilicon
+        case unsupported
+    }
+
+    public static let shared = VoxtralRuntimeManager()
+    private static let minimumPythonMajor = 3
+    private static let minimumPythonMinor = 10
+    private static let minimumPythonSpecifier = "3.10"
+
+    @Published public private(set) var status: VoxtralRuntimeStatus = .notInstalled
+    @Published public private(set) var recentLogs: [String] = []
+    @Published public private(set) var installedVersion: String = "unknown"
+    @Published public private(set) var lastError: String?
+    @Published public private(set) var lastHealthCheckAt: Date?
+
+    private struct RuntimePaths {
+        let baseDirectory: URL
+        let venvDirectory: URL
+        let pythonBinary: URL
+        let vllmBinary: URL
+        let mlxAudioServerBinary: URL
+        let logDirectory: URL
+        let logFile: URL
+    }
+
+    private struct ServerLaunchConfig {
+        let host: String
+        let port: Int
+        let modelID: String
+        let apiKey: String?
+        let venvPath: String?
+        let autoRestart: Bool
+    }
+
+    private var serverProcess: Process?
+    private var stdoutPipe: Pipe?
+    private var stderrPipe: Pipe?
+    private var logFileHandle: FileHandle?
+    private let fileManager = FileManager.default
+    private let ioQueue = DispatchQueue(label: "com.hibiki.voxtral-runtime.io")
+    private var isStopping = false
+    private var restartAttempt = 0
+    private var launchConfig: ServerLaunchConfig?
+
+    public static var backendKind: BackendKind {
+#if os(Linux)
+        .vllmOmniLinux
+#elseif os(macOS) && arch(arm64)
+        .mlxAudioAppleSilicon
+#else
+        .unsupported
+#endif
+    }
+
+    public static var isManagedRuntimeSupportedOnCurrentPlatform: Bool {
+        backendKind != .unsupported
+    }
+
+    public static var unsupportedPlatformDescription: String {
+#if os(macOS)
+        "this Mac configuration"
+#elseif os(Linux)
+        "Linux"
+#else
+        "this platform"
+#endif
+    }
+
+    public static var backendDisplayName: String {
+        switch backendKind {
+        case .vllmOmniLinux:
+            return "vLLM Omni"
+        case .mlxAudioAppleSilicon:
+            return "MLX-Audio"
+        case .unsupported:
+            return "Unsupported"
+        }
+    }
+
+    public static var defaultManagedModelID: String {
+        switch backendKind {
+        case .vllmOmniLinux:
+            return MistralLocalTTSDefaults.modelID
+        case .mlxAudioAppleSilicon:
+            return MistralLocalTTSDefaults.mlxModelID
+        case .unsupported:
+            return MistralLocalTTSDefaults.modelID
+        }
+    }
+
+    public static func defaultVenvPath() -> String {
+        let fm = FileManager.default
+        let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSString(string: "~/Library/Application Support").expandingTildeInPath)
+        return appSupport
+            .appendingPathComponent("Hibiki", isDirectory: true)
+            .appendingPathComponent("voxtral-tts", isDirectory: true)
+            .appendingPathComponent(".venv", isDirectory: true)
+            .path
+    }
+
+    public var isRunning: Bool {
+        serverProcess?.isRunning == true && status == .running
+    }
+
+    public func hasInstalledRuntime(venvPath: String? = nil) -> Bool {
+        guard Self.isManagedRuntimeSupportedOnCurrentPlatform else {
+            return false
+        }
+        let paths = runtimePaths(venvPath: venvPath)
+        let runtimeBinaryInstalled: Bool
+        switch Self.backendKind {
+        case .vllmOmniLinux:
+            runtimeBinaryInstalled = fileManager.isExecutableFile(atPath: paths.vllmBinary.path)
+        case .mlxAudioAppleSilicon:
+            runtimeBinaryInstalled = fileManager.isExecutableFile(atPath: paths.mlxAudioServerBinary.path)
+        case .unsupported:
+            runtimeBinaryInstalled = false
+        }
+
+        return runtimeBinaryInstalled && fileManager.isExecutableFile(atPath: paths.pythonBinary.path)
+    }
+
+    @MainActor
+    public func installIfNeeded(venvPath: String? = nil) async throws {
+        guard Self.isManagedRuntimeSupportedOnCurrentPlatform else {
+            status = .failed
+            lastError = VoxtralRuntimeError.unsupportedPlatform(Self.unsupportedPlatformDescription).localizedDescription
+            throw VoxtralRuntimeError.unsupportedPlatform(Self.unsupportedPlatformDescription)
+        }
+        let paths = runtimePaths(venvPath: venvPath)
+        let runtimeBinaryInstalled: Bool
+        switch Self.backendKind {
+        case .vllmOmniLinux:
+            runtimeBinaryInstalled = fileManager.isExecutableFile(atPath: paths.vllmBinary.path)
+        case .mlxAudioAppleSilicon:
+            runtimeBinaryInstalled = fileManager.isExecutableFile(atPath: paths.mlxAudioServerBinary.path)
+        case .unsupported:
+            runtimeBinaryInstalled = false
+        }
+
+        if runtimeBinaryInstalled,
+           fileManager.isExecutableFile(atPath: paths.pythonBinary.path),
+           let isSupported = try await isManagedPythonVersionSupported(pythonBinary: paths.pythonBinary.path),
+           isSupported {
+            status = .installed
+            try await refreshInstalledVersion(venvPath: venvPath)
+            return
+        }
+
+        if fileManager.fileExists(atPath: paths.venvDirectory.path) {
+            appendLogLine("Existing managed venv is incompatible; reinstalling with Python 3.10+.")
+        }
+        try await reinstall(venvPath: venvPath)
+    }
+
+    @MainActor
+    public func reinstall(venvPath: String? = nil) async throws {
+        guard Self.isManagedRuntimeSupportedOnCurrentPlatform else {
+            status = .failed
+            lastError = VoxtralRuntimeError.unsupportedPlatform(Self.unsupportedPlatformDescription).localizedDescription
+            throw VoxtralRuntimeError.unsupportedPlatform(Self.unsupportedPlatformDescription)
+        }
+        status = .installing
+        lastError = nil
+        appendLogLine("Installing Voxtral runtime with uv...")
+
+        guard let uvBinary = resolveUVBinary() else {
+            status = .failed
+            lastError = VoxtralRuntimeError.uvMissing.localizedDescription
+            throw VoxtralRuntimeError.uvMissing
+        }
+
+        let paths = runtimePaths(venvPath: venvPath)
+        try ensureDirectories(paths: paths)
+
+        if fileManager.fileExists(atPath: paths.venvDirectory.path) {
+            do {
+                try fileManager.removeItem(at: paths.venvDirectory)
+            } catch {
+                status = .failed
+                lastError = VoxtralRuntimeError.installFailed(
+                    step: "remove incompatible venv",
+                    output: error.localizedDescription
+                ).localizedDescription
+                throw VoxtralRuntimeError.installFailed(
+                    step: "remove incompatible venv",
+                    output: error.localizedDescription
+                )
+            }
+        }
+
+        let createVenvResult = try await runCommand(
+            executablePath: uvBinary,
+            arguments: [
+                "venv",
+                paths.venvDirectory.path,
+                "--python",
+                Self.minimumPythonSpecifier
+            ]
+        )
+        guard createVenvResult.exitCode == 0 else {
+            status = .failed
+            lastError = VoxtralRuntimeError.installFailed(step: "uv venv", output: createVenvResult.output).localizedDescription
+            throw VoxtralRuntimeError.installFailed(step: "uv venv", output: createVenvResult.output)
+        }
+
+        if let isSupported = try await isManagedPythonVersionSupported(pythonBinary: paths.pythonBinary.path),
+           !isSupported {
+            status = .failed
+            let output = "Managed venv uses unsupported Python version. Voxtral requires Python >=3.10."
+            lastError = VoxtralRuntimeError.installFailed(step: "python version check", output: output).localizedDescription
+            throw VoxtralRuntimeError.installFailed(step: "python version check", output: output)
+        }
+
+        switch Self.backendKind {
+        case .vllmOmniLinux:
+            let installVLLMResult = try await runCommand(
+                executablePath: uvBinary,
+                arguments: [
+                    "pip",
+                    "install",
+                    "--python",
+                    paths.pythonBinary.path,
+                    "--upgrade",
+                    "vllm>=0.18.0"
+                ]
+            )
+            guard installVLLMResult.exitCode == 0 else {
+                status = .failed
+                lastError = VoxtralRuntimeError.installFailed(step: "uv pip install vllm", output: installVLLMResult.output).localizedDescription
+                throw VoxtralRuntimeError.installFailed(step: "uv pip install vllm", output: installVLLMResult.output)
+            }
+
+            let installOmniResult = try await runCommand(
+                executablePath: uvBinary,
+                arguments: [
+                    "pip",
+                    "install",
+                    "--python",
+                    paths.pythonBinary.path,
+                    "--upgrade",
+                    "git+https://github.com/vllm-project/vllm-omni.git"
+                ]
+            )
+            guard installOmniResult.exitCode == 0 else {
+                status = .failed
+                lastError = VoxtralRuntimeError.installFailed(step: "uv pip install vllm-omni", output: installOmniResult.output).localizedDescription
+                throw VoxtralRuntimeError.installFailed(step: "uv pip install vllm-omni", output: installOmniResult.output)
+            }
+        case .mlxAudioAppleSilicon:
+            let installMLXAudioResult = try await runCommand(
+                executablePath: uvBinary,
+                arguments: [
+                    "pip",
+                    "install",
+                    "--python",
+                    paths.pythonBinary.path,
+                    "--upgrade",
+                    "mlx-audio[all]"
+                ]
+            )
+            guard installMLXAudioResult.exitCode == 0 else {
+                status = .failed
+                lastError = VoxtralRuntimeError.installFailed(step: "uv pip install mlx-audio", output: installMLXAudioResult.output).localizedDescription
+                throw VoxtralRuntimeError.installFailed(step: "uv pip install mlx-audio", output: installMLXAudioResult.output)
+            }
+        case .unsupported:
+            break
+        }
+
+        try await refreshInstalledVersion(venvPath: venvPath)
+        status = .installed
+        appendLogLine("Voxtral runtime installation complete.")
+    }
+
+    @MainActor
+    public func startServer(
+        host: String,
+        port: Int,
+        modelID: String,
+        apiKey: String? = nil,
+        venvPath: String? = nil,
+        autoRestart: Bool = false
+    ) async throws {
+        guard Self.isManagedRuntimeSupportedOnCurrentPlatform else {
+            status = .failed
+            lastError = VoxtralRuntimeError.unsupportedPlatform(Self.unsupportedPlatformDescription).localizedDescription
+            throw VoxtralRuntimeError.unsupportedPlatform(Self.unsupportedPlatformDescription)
+        }
+        let normalizedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.isLoopbackHost(normalizedHost) else {
+            let error = VoxtralRuntimeError.invalidHost(normalizedHost)
+            status = .failed
+            lastError = error.localizedDescription
+            throw error
+        }
+
+        let effectiveModelID = modelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? Self.defaultManagedModelID
+            : modelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let effectiveAPIKey = normalizedOptional(apiKey)
+        let paths = runtimePaths(venvPath: venvPath)
+
+        let executableURL: URL?
+        switch Self.backendKind {
+        case .vllmOmniLinux:
+            executableURL = fileManager.isExecutableFile(atPath: paths.vllmBinary.path) ? paths.vllmBinary : nil
+        case .mlxAudioAppleSilicon:
+            executableURL = fileManager.isExecutableFile(atPath: paths.mlxAudioServerBinary.path) ? paths.mlxAudioServerBinary : nil
+        case .unsupported:
+            executableURL = nil
+        }
+
+        guard let executableURL else {
+            status = .failed
+            lastError = VoxtralRuntimeError.runtimeNotInstalled.localizedDescription
+            throw VoxtralRuntimeError.runtimeNotInstalled
+        }
+
+        stopServer()
+
+        try ensureDirectories(paths: paths)
+        try openLogHandle(paths: paths)
+
+        isStopping = false
+        status = .starting
+        lastError = nil
+        launchConfig = ServerLaunchConfig(
+            host: normalizedHost,
+            port: port,
+            modelID: effectiveModelID,
+            apiKey: effectiveAPIKey,
+            venvPath: venvPath,
+            autoRestart: autoRestart
+        )
+        appendLogLine("Starting Voxtral server on \(normalizedHost):\(port)")
+
+        let process = Process()
+        process.executableURL = executableURL
+        var arguments: [String]
+        switch Self.backendKind {
+        case .vllmOmniLinux:
+            arguments = [
+                "serve",
+                effectiveModelID,
+                "--omni",
+                "--host", normalizedHost,
+                "--port", String(port),
+            ]
+            if let effectiveAPIKey {
+                arguments.append(contentsOf: ["--api-key", effectiveAPIKey])
+            }
+        case .mlxAudioAppleSilicon:
+            arguments = [
+                "--host", normalizedHost,
+                "--port", String(port),
+                "--log-dir", paths.logDirectory.path,
+            ]
+        case .unsupported:
+            arguments = []
+        }
+        process.arguments = arguments
+        process.environment = ProcessInfo.processInfo.environment
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        self.stdoutPipe = stdoutPipe
+        self.stderrPipe = stderrPipe
+        self.serverProcess = process
+
+        stdoutPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            self?.recordProcessOutput(data)
+        }
+        stderrPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            self?.recordProcessOutput(data)
+        }
+
+        process.terminationHandler = { [weak self] process in
+            Task { @MainActor [weak self] in
+                self?.handleProcessTermination(exitCode: process.terminationStatus)
+            }
+        }
+
+        do {
+            try process.run()
+        } catch {
+            status = .failed
+            lastError = VoxtralRuntimeError.startupFailed(message: error.localizedDescription).localizedDescription
+            cleanupPipesAndHandles()
+            throw VoxtralRuntimeError.startupFailed(message: error.localizedDescription)
+        }
+
+        let baseURL = Self.baseURL(host: normalizedHost, port: port)
+        let healthy = await waitForHealthy(baseURL: baseURL, apiKey: effectiveAPIKey, timeoutSeconds: 25)
+        if healthy, serverProcess?.isRunning == true {
+            status = .running
+            restartAttempt = 0
+            appendLogLine("Voxtral server is healthy.")
+            return
+        }
+
+        stopServer()
+        status = .failed
+        lastError = VoxtralRuntimeError.startTimedOut.localizedDescription
+        throw VoxtralRuntimeError.startTimedOut
+    }
+
+    @MainActor
+    public func stopServer() {
+        guard let process = serverProcess else {
+            status = .stopped
+            cleanupPipesAndHandles()
+            return
+        }
+
+        isStopping = true
+        if process.isRunning {
+            process.terminate()
+        }
+
+        stdoutPipe?.fileHandleForReading.readabilityHandler = nil
+        stderrPipe?.fileHandleForReading.readabilityHandler = nil
+        status = .stopped
+    }
+
+    @MainActor
+    public func restartServer(
+        host: String,
+        port: Int,
+        modelID: String,
+        apiKey: String? = nil,
+        venvPath: String? = nil,
+        autoRestart: Bool = false
+    ) async throws {
+        stopServer()
+        try await startServer(
+            host: host,
+            port: port,
+            modelID: modelID,
+            apiKey: apiKey,
+            venvPath: venvPath,
+            autoRestart: autoRestart
+        )
+    }
+
+    @MainActor
+    public func healthCheck(baseURL: String, apiKey: String?) async -> VoxtralRuntimeHealth {
+        guard let voicesURL = voicesURL(baseURL: baseURL) else {
+            return VoxtralRuntimeHealth(isHealthy: false, statusCode: nil, message: "Invalid base URL", isVoxtralAPI: false)
+        }
+
+        var request = URLRequest(url: voicesURL)
+        request.timeoutInterval = 2.0
+        if let token = normalizedOptional(apiKey) {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let httpStatus = (response as? HTTPURLResponse)?.statusCode
+            lastHealthCheckAt = Date()
+            if httpStatus == 200, voicesPayloadLooksHealthy(data) {
+                return VoxtralRuntimeHealth(
+                    isHealthy: true,
+                    statusCode: 200,
+                    message: nil,
+                    isVoxtralAPI: true
+                )
+            }
+        } catch {
+        }
+
+        guard let openAPIURL = openAPIURL(baseURL: baseURL) else {
+            return VoxtralRuntimeHealth(
+                isHealthy: false,
+                statusCode: nil,
+                message: "Invalid base URL",
+                isVoxtralAPI: false
+            )
+        }
+
+        var openAPIRequest = URLRequest(url: openAPIURL)
+        openAPIRequest.timeoutInterval = 2.0
+        if let token = normalizedOptional(apiKey) {
+            openAPIRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: openAPIRequest)
+            let httpStatus = (response as? HTTPURLResponse)?.statusCode
+            lastHealthCheckAt = Date()
+            guard httpStatus == 200 else {
+                return VoxtralRuntimeHealth(
+                    isHealthy: false,
+                    statusCode: httpStatus,
+                    message: "HTTP \(httpStatus ?? -1)",
+                    isVoxtralAPI: false
+                )
+            }
+
+            if openAPIHasSpeechEndpoint(data) {
+                return VoxtralRuntimeHealth(
+                    isHealthy: true,
+                    statusCode: 200,
+                    message: nil,
+                    isVoxtralAPI: true
+                )
+            }
+
+            return VoxtralRuntimeHealth(
+                isHealthy: false,
+                statusCode: httpStatus,
+                message: "OpenAPI payload is not Voxtral-compatible.",
+                isVoxtralAPI: false
+            )
+        } catch {
+            return VoxtralRuntimeHealth(
+                isHealthy: false,
+                statusCode: nil,
+                message: error.localizedDescription,
+                isVoxtralAPI: false
+            )
+        }
+    }
+
+    @MainActor
+    public func clearLastError() {
+        lastError = nil
+    }
+
+    @MainActor
+    private func waitForHealthy(baseURL: String, apiKey: String?, timeoutSeconds: TimeInterval) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if Task.isCancelled {
+                return false
+            }
+            guard serverProcess?.isRunning == true else {
+                return false
+            }
+            let health = await healthCheck(baseURL: baseURL, apiKey: apiKey)
+            if health.isHealthy {
+                return true
+            }
+            guard serverProcess?.isRunning == true else {
+                return false
+            }
+            try? await Task.sleep(nanoseconds: 300_000_000)
+        }
+        return false
+    }
+
+    @MainActor
+    private func refreshInstalledVersion(venvPath: String? = nil) async throws {
+        let paths = runtimePaths(venvPath: venvPath)
+        guard fileManager.isExecutableFile(atPath: paths.pythonBinary.path) else {
+            installedVersion = "unknown"
+            return
+        }
+
+        let result = try await runCommand(
+            executablePath: paths.pythonBinary.path,
+            arguments: [
+                "-c",
+                packageVersionCheckScript()
+            ]
+        )
+
+        guard result.exitCode == 0 else {
+            installedVersion = "unknown"
+            return
+        }
+        let trimmed = result.output
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: "\n")
+            .last
+            .map(String.init)
+        installedVersion = trimmed?.isEmpty == false ? trimmed! : "unknown"
+    }
+
+    @MainActor
+    private func handleProcessTermination(exitCode: Int32) {
+        defer {
+            serverProcess = nil
+            cleanupPipesAndHandles()
+        }
+
+        if isStopping {
+            isStopping = false
+            status = .stopped
+            appendLogLine("Voxtral server stopped.")
+            return
+        }
+
+        appendLogLine("Voxtral server exited unexpectedly (\(exitCode)).")
+
+        guard let config = launchConfig, config.autoRestart, restartAttempt < 5 else {
+            status = .failed
+            lastError = "Voxtral server exited unexpectedly (code \(exitCode))."
+            return
+        }
+
+        let delays: [UInt64] = [1, 2, 5, 5, 5]
+        let delaySeconds = delays[min(restartAttempt, delays.count - 1)]
+        restartAttempt += 1
+        status = .unhealthy
+        appendLogLine("Restarting Voxtral in \(delaySeconds)s (attempt \(restartAttempt)/5)")
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: delaySeconds * 1_000_000_000)
+            guard self.serverProcess == nil else { return }
+            do {
+                try await self.startServer(
+                    host: config.host,
+                    port: config.port,
+                    modelID: config.modelID,
+                    apiKey: config.apiKey,
+                    venvPath: config.venvPath,
+                    autoRestart: config.autoRestart
+                )
+            } catch {
+                self.status = .failed
+                self.lastError = error.localizedDescription
+            }
+        }
+    }
+
+    private func runtimePaths(venvPath: String?) -> RuntimePaths {
+        let resolvedVenvPath = normalizedPath(venvPath ?? Self.defaultVenvPath())
+        let venvDirectory = URL(fileURLWithPath: resolvedVenvPath, isDirectory: true)
+        let baseDirectory = venvDirectory.deletingLastPathComponent()
+        let logDirectory = baseDirectory.appendingPathComponent("logs", isDirectory: true)
+        return RuntimePaths(
+            baseDirectory: baseDirectory,
+            venvDirectory: venvDirectory,
+            pythonBinary: venvDirectory.appendingPathComponent("bin/python"),
+            vllmBinary: venvDirectory.appendingPathComponent("bin/vllm"),
+            mlxAudioServerBinary: venvDirectory.appendingPathComponent("bin/mlx_audio.server"),
+            logDirectory: logDirectory,
+            logFile: logDirectory.appendingPathComponent("server.log")
+        )
+    }
+
+    private func normalizedPath(_ path: String) -> String {
+        NSString(string: path).expandingTildeInPath
+    }
+
+    private func normalizedOptional(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func ensureDirectories(paths: RuntimePaths) throws {
+        try fileManager.createDirectory(at: paths.baseDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: paths.logDirectory, withIntermediateDirectories: true)
+    }
+
+    private func openLogHandle(paths: RuntimePaths) throws {
+        if !fileManager.fileExists(atPath: paths.logFile.path) {
+            fileManager.createFile(atPath: paths.logFile.path, contents: Data())
+        }
+        let handle = try FileHandle(forWritingTo: paths.logFile)
+        handle.seekToEndOfFile()
+        logFileHandle = handle
+    }
+
+    private func cleanupPipesAndHandles() {
+        stdoutPipe?.fileHandleForReading.readabilityHandler = nil
+        stderrPipe?.fileHandleForReading.readabilityHandler = nil
+        stdoutPipe = nil
+        stderrPipe = nil
+
+        ioQueue.async { [weak self] in
+            self?.logFileHandle?.closeFile()
+            self?.logFileHandle = nil
+        }
+    }
+
+    private func recordProcessOutput(_ data: Data) {
+        ioQueue.async { [weak self] in
+            guard let self else { return }
+
+            self.logFileHandle?.write(data)
+
+            guard let text = String(data: data, encoding: .utf8) else { return }
+            let lines = text
+                .split(whereSeparator: \.isNewline)
+                .map(String.init)
+                .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
+            guard !lines.isEmpty else { return }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.recentLogs.append(contentsOf: lines)
+                if self.recentLogs.count > 200 {
+                    self.recentLogs.removeFirst(self.recentLogs.count - 200)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func appendLogLine(_ line: String) {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        recentLogs.append(trimmed)
+        if recentLogs.count > 200 {
+            recentLogs.removeFirst(recentLogs.count - 200)
+        }
+    }
+
+    private func runCommand(
+        executablePath: String,
+        arguments: [String]
+    ) async throws -> (exitCode: Int32, output: String) {
+        try await withCheckedThrowingContinuation { continuation in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: executablePath)
+            process.arguments = arguments
+            process.environment = ProcessInfo.processInfo.environment
+
+            let outputPipe = Pipe()
+            process.standardOutput = outputPipe
+            process.standardError = outputPipe
+
+            process.terminationHandler = { process in
+                let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: data, encoding: .utf8) ?? ""
+                continuation.resume(returning: (process.terminationStatus, output))
+            }
+
+            do {
+                try process.run()
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    private func isManagedPythonVersionSupported(pythonBinary: String) async throws -> Bool? {
+        guard fileManager.isExecutableFile(atPath: pythonBinary) else {
+            return nil
+        }
+
+        let result = try await runCommand(
+            executablePath: pythonBinary,
+            arguments: [
+                "-c",
+                "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
+            ]
+        )
+
+        guard result.exitCode == 0 else {
+            return nil
+        }
+
+        let versionLine = result.output
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: "\n")
+            .last
+            .map(String.init)
+
+        guard let versionLine,
+              let major = Int(versionLine.split(separator: ".").first ?? ""),
+              let minorString = versionLine.split(separator: ".").dropFirst().first,
+              let minor = Int(minorString) else {
+            return nil
+        }
+
+        if major > Self.minimumPythonMajor {
+            return true
+        }
+        if major == Self.minimumPythonMajor && minor >= Self.minimumPythonMinor {
+            return true
+        }
+        return false
+    }
+
+    private func resolveUVBinary() -> String? {
+        let environment = ProcessInfo.processInfo.environment
+        if let pathValue = environment["PATH"] {
+            let paths = pathValue.split(separator: ":").map(String.init)
+            for directory in paths {
+                let candidate = URL(fileURLWithPath: directory).appendingPathComponent("uv").path
+                if fileManager.isExecutableFile(atPath: candidate) {
+                    return candidate
+                }
+            }
+        }
+
+        let home = NSHomeDirectory()
+        let fallbackCandidates = [
+            "\(home)/.local/bin/uv",
+            "/opt/homebrew/bin/uv",
+            "/usr/local/bin/uv"
+        ]
+        for candidate in fallbackCandidates where fileManager.isExecutableFile(atPath: candidate) {
+            return candidate
+        }
+        return nil
+    }
+
+    private func voicesPayloadLooksHealthy(_ data: Data) -> Bool {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let voices = json["voices"] as? [String] else {
+            return false
+        }
+        return !voices.isEmpty
+    }
+
+    private func openAPIHasSpeechEndpoint(_ data: Data) -> Bool {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let paths = json["paths"] as? [String: Any] else {
+            return false
+        }
+        return paths["/v1/audio/speech"] != nil || paths["/audio/speech"] != nil
+    }
+
+    private func voicesURL(baseURL: String) -> URL? {
+        guard var components = URLComponents(string: baseURL) else { return nil }
+        let path = components.path
+        if path.isEmpty || path == "/" {
+            components.path = "/v1/audio/voices"
+        } else if path.hasSuffix("/v1/audio/voices") {
+            return components.url
+        } else if path.hasSuffix("/v1") {
+            components.path = "\(path)/audio/voices"
+        } else {
+            components.path = path.hasSuffix("/") ? "\(path)v1/audio/voices" : "\(path)/v1/audio/voices"
+        }
+        return components.url
+    }
+
+    private func openAPIURL(baseURL: String) -> URL? {
+        URL(string: baseURL)?.appending(path: "openapi.json")
+    }
+
+    private func packageVersionCheckScript() -> String {
+        switch Self.backendKind {
+        case .vllmOmniLinux:
+            return "import importlib.metadata as m; print(m.version('vllm'))"
+        case .mlxAudioAppleSilicon:
+            return "import importlib.metadata as m; print(m.version('mlx-audio'))"
+        case .unsupported:
+            return "print('unknown')"
+        }
+    }
+
+    public static func baseURL(host: String, port: Int) -> String {
+        "http://\(host):\(port)"
+    }
+
+    private static func isLoopbackHost(_ host: String) -> Bool {
+        let normalized = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized == "127.0.0.1" || normalized == "localhost" || normalized == "::1"
+    }
+}

--- a/Sources/HibikiPocketRuntime/VoxtralRuntimeTypes.swift
+++ b/Sources/HibikiPocketRuntime/VoxtralRuntimeTypes.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+public enum VoxtralRuntimeStatus: String {
+    case notInstalled
+    case installing
+    case installed
+    case starting
+    case running
+    case unhealthy
+    case stopped
+    case failed
+
+    public var displayName: String {
+        switch self {
+        case .notInstalled: return "Not installed"
+        case .installing: return "Installing"
+        case .installed: return "Installed"
+        case .starting: return "Starting"
+        case .running: return "Running"
+        case .unhealthy: return "Unhealthy"
+        case .stopped: return "Stopped"
+        case .failed: return "Failed"
+        }
+    }
+}
+
+public struct VoxtralRuntimeHealth {
+    public let isHealthy: Bool
+    public let statusCode: Int?
+    public let message: String?
+    public let isVoxtralAPI: Bool
+
+    public init(isHealthy: Bool, statusCode: Int?, message: String?, isVoxtralAPI: Bool) {
+        self.isHealthy = isHealthy
+        self.statusCode = statusCode
+        self.message = message
+        self.isVoxtralAPI = isVoxtralAPI
+    }
+}
+
+public enum VoxtralRuntimeError: LocalizedError {
+    case unsupportedPlatform(String)
+    case uvMissing
+    case invalidHost(String)
+    case installFailed(step: String, output: String)
+    case runtimeNotInstalled
+    case startupFailed(message: String)
+    case startTimedOut
+    case healthCheckFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedPlatform(let platform):
+            return "Managed Voxtral runtime is not supported on \(platform). Use a manual endpoint backed by a Linux GPU host running vllm/vllm-omni."
+        case .uvMissing:
+            return "uv was not found. Install uv and retry Voxtral setup."
+        case .invalidHost(let host):
+            return "Managed Voxtral runtime only supports localhost. Invalid host: \(host)"
+        case .installFailed(let step, let output):
+            let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                return "Voxtral install failed at step: \(step)."
+            }
+            return "Voxtral install failed at step: \(step). \(trimmed)"
+        case .runtimeNotInstalled:
+            return "Voxtral runtime is not installed."
+        case .startupFailed(let message):
+            return "Voxtral failed to start. \(message)"
+        case .startTimedOut:
+            return "Voxtral server did not become healthy in time."
+        case .healthCheckFailed:
+            return "Voxtral health check failed."
+        }
+    }
+}

--- a/Sources/HibikiShared/LocalTTSSupport.swift
+++ b/Sources/HibikiShared/LocalTTSSupport.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+public enum MistralLocalTTSDefaults {
+    public static let baseURL = "http://127.0.0.1:8091"
+    public static let modelID = "mistralai/Voxtral-4B-TTS-2603"
+    public static let mlxModelID = "mlx-community/Voxtral-4B-TTS-2603-mlx-bf16"
+    public static let voice = "casual_male"
+    public static let requestTimeoutSec: Double = 180
+}
+
+public struct MistralLocalTTSConfiguration: Equatable, Sendable {
+    public let mistralLocalBaseURL: String
+    public let mistralLocalModelID: String
+    public let mistralLocalVoice: String
+
+    public init(
+        mistralLocalBaseURL: String,
+        mistralLocalModelID: String,
+        mistralLocalVoice: String
+    ) {
+        self.mistralLocalBaseURL = mistralLocalBaseURL
+        self.mistralLocalModelID = mistralLocalModelID
+        self.mistralLocalVoice = mistralLocalVoice
+    }
+
+    public var normalizedBaseURL: String {
+        let trimmed = mistralLocalBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return MistralLocalTTSDefaults.baseURL }
+        if trimmed.hasPrefix("http://") || trimmed.hasPrefix("https://") {
+            return trimmed
+        }
+        return "http://\(trimmed)"
+    }
+
+    public var normalizedModelID: String {
+        let trimmed = mistralLocalModelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? MistralLocalTTSDefaults.modelID : trimmed
+    }
+
+    public var normalizedVoice: String {
+        let trimmed = mistralLocalVoice.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? MistralLocalTTSDefaults.voice : trimmed
+    }
+
+    public var historyVoiceLabel: String {
+        "\(LocalTTSVoiceLabel.mistralPrefix)\(normalizedVoice)"
+    }
+
+    public var speechURL: URL? {
+        guard var components = URLComponents(string: normalizedBaseURL) else { return nil }
+        let path = components.path
+        if path.isEmpty || path == "/" {
+            components.path = "/v1/audio/speech"
+        } else if path.hasSuffix("/v1/audio/speech") {
+            return components.url
+        } else if path.hasSuffix("/v1") {
+            components.path = "\(path)/audio/speech"
+        } else {
+            components.path = path.hasSuffix("/") ? "\(path)v1/audio/speech" : "\(path)/v1/audio/speech"
+        }
+        return components.url
+    }
+}
+
+public enum LocalTTSVoiceLabel {
+    public static let pocketPrefix = "pocket:"
+    public static let mistralPrefix = "mistral:"
+
+    public static func isLocal(_ voice: String) -> Bool {
+        isPocket(voice) || isMistral(voice)
+    }
+
+    public static func isPocket(_ voice: String) -> Bool {
+        voice.hasPrefix(pocketPrefix)
+    }
+
+    public static func isMistral(_ voice: String) -> Bool {
+        voice.hasPrefix(mistralPrefix)
+    }
+}

--- a/Tests/HibikiTests/MistralLocalConfigurationTests.swift
+++ b/Tests/HibikiTests/MistralLocalConfigurationTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import HibikiShared
+
+final class MistralLocalConfigurationTests: XCTestCase {
+    func testMistralLocalDefaultBaseURLMatchesManagedServerPort() {
+        let configuration = makeConfiguration()
+
+        XCTAssertEqual(configuration.normalizedBaseURL, "http://127.0.0.1:8091")
+        XCTAssertEqual(
+            configuration.speechURL?.absoluteString,
+            "http://127.0.0.1:8091/v1/audio/speech"
+        )
+    }
+
+    func testMistralLocalBaseURLDefaultsToOpenAICompatibleSpeechEndpoint() {
+        let configuration = makeConfiguration(mistralLocalBaseURL: "127.0.0.1:9999")
+
+        XCTAssertEqual(configuration.normalizedBaseURL, "http://127.0.0.1:9999")
+        XCTAssertEqual(
+            configuration.speechURL?.absoluteString,
+            "http://127.0.0.1:9999/v1/audio/speech"
+        )
+    }
+
+    func testMistralLocalFallsBackToDefaultModelAndVoice() {
+        let configuration = makeConfiguration(
+            mistralLocalModelID: "   ",
+            mistralLocalVoice: ""
+        )
+
+        XCTAssertEqual(
+            configuration.normalizedModelID,
+            MistralLocalTTSDefaults.modelID
+        )
+        XCTAssertEqual(
+            configuration.normalizedVoice,
+            MistralLocalTTSDefaults.voice
+        )
+        XCTAssertEqual(configuration.historyVoiceLabel, "mistral:\(MistralLocalTTSDefaults.voice)")
+    }
+
+    func testMistralLocalVoiceLabelsAreClassifiedAsFreeLocalAudio() {
+        XCTAssertTrue(LocalTTSVoiceLabel.isLocal("mistral:casual_male"))
+        XCTAssertTrue(LocalTTSVoiceLabel.isMistral("mistral:casual_male"))
+        XCTAssertFalse(LocalTTSVoiceLabel.isMistral("pocket:alba"))
+    }
+
+    private func makeConfiguration(
+        mistralLocalBaseURL: String = "",
+        mistralLocalModelID: String = MistralLocalTTSDefaults.modelID,
+        mistralLocalVoice: String = MistralLocalTTSDefaults.voice
+    ) -> MistralLocalTTSConfiguration {
+        MistralLocalTTSConfiguration(
+            mistralLocalBaseURL: mistralLocalBaseURL,
+            mistralLocalModelID: mistralLocalModelID,
+            mistralLocalVoice: mistralLocalVoice
+        )
+    }
+}

--- a/Tests/HibikiTests/VoxtralRuntimeHealthTests.swift
+++ b/Tests/HibikiTests/VoxtralRuntimeHealthTests.swift
@@ -1,0 +1,204 @@
+import XCTest
+@testable import HibikiPocketRuntime
+
+final class VoxtralRuntimeHealthTests: XCTestCase {
+    private var processes: [Process] = []
+
+    override func tearDown() {
+        for process in processes where process.isRunning {
+            process.terminate()
+            process.waitUntilExit()
+        }
+        processes.removeAll()
+        super.tearDown()
+    }
+
+    func testManagedRuntimeSupportMatchesCurrentPlatform() {
+#if os(Linux)
+        XCTAssertTrue(VoxtralRuntimeManager.isManagedRuntimeSupportedOnCurrentPlatform)
+#elseif os(macOS) && arch(arm64)
+        XCTAssertTrue(VoxtralRuntimeManager.isManagedRuntimeSupportedOnCurrentPlatform)
+#else
+        XCTAssertFalse(VoxtralRuntimeManager.isManagedRuntimeSupportedOnCurrentPlatform)
+#endif
+    }
+
+    func testHealthCheckRejectsNonVoxtralServer() async throws {
+        let port = try freeTCPPort()
+        _ = try launchProcess(
+            executable: "/usr/bin/python3",
+            arguments: ["-m", "http.server", String(port)]
+        )
+
+        try await waitUntilReachable(url: URL(string: "http://127.0.0.1:\(port)/")!)
+
+        let health = await VoxtralRuntimeManager.shared.healthCheck(
+            baseURL: "http://127.0.0.1:\(port)",
+            apiKey: nil
+        )
+
+        XCTAssertFalse(health.isHealthy)
+        XCTAssertFalse(health.isVoxtralAPI)
+        XCTAssertEqual(health.statusCode, 404)
+    }
+
+    func testHealthCheckAcceptsVoxtralCompatibleServer() async throws {
+        let port = try freeTCPPort()
+        let script = #"""
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+port = int(sys.argv[1])
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/v1/audio/voices':
+            payload = json.dumps({
+                'voices': ['casual_male', 'calm_female']
+            }).encode('utf-8')
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.send_header('Content-Length', str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, _format, *_args):
+        return
+
+HTTPServer(('127.0.0.1', port), Handler).serve_forever()
+"""#
+
+        _ = try launchProcess(
+            executable: "/usr/bin/python3",
+            arguments: ["-c", script, String(port)]
+        )
+
+        try await waitUntilReachable(url: URL(string: "http://127.0.0.1:\(port)/v1/audio/voices")!)
+
+        let health = await VoxtralRuntimeManager.shared.healthCheck(
+            baseURL: "http://127.0.0.1:\(port)",
+            apiKey: nil
+        )
+
+        XCTAssertTrue(health.isHealthy)
+        XCTAssertTrue(health.isVoxtralAPI)
+        XCTAssertEqual(health.statusCode, 200)
+        XCTAssertNil(health.message)
+    }
+
+    func testHealthCheckAcceptsOpenAISpeechCompatibleServer() async throws {
+        let port = try freeTCPPort()
+        let script = #"""
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+port = int(sys.argv[1])
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/openapi.json':
+            payload = json.dumps({
+                'openapi': '3.1.0',
+                'info': {'title': 'MLX Audio API'},
+                'paths': {'/v1/audio/speech': {'post': {}}},
+            }).encode('utf-8')
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.send_header('Content-Length', str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, _format, *_args):
+        return
+
+HTTPServer(('127.0.0.1', port), Handler).serve_forever()
+"""#
+
+        _ = try launchProcess(
+            executable: "/usr/bin/python3",
+            arguments: ["-c", script, String(port)]
+        )
+
+        try await waitUntilReachable(url: URL(string: "http://127.0.0.1:\(port)/openapi.json")!)
+
+        let health = await VoxtralRuntimeManager.shared.healthCheck(
+            baseURL: "http://127.0.0.1:\(port)",
+            apiKey: nil
+        )
+
+        XCTAssertTrue(health.isHealthy)
+        XCTAssertTrue(health.isVoxtralAPI)
+        XCTAssertEqual(health.statusCode, 200)
+        XCTAssertNil(health.message)
+    }
+
+    private func launchProcess(executable: String, arguments: [String]) throws -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+
+        try process.run()
+        processes.append(process)
+        return process
+    }
+
+    private func freeTCPPort() throws -> Int {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        process.arguments = [
+            "-c",
+            "import socket; s=socket.socket(); s.bind(('127.0.0.1', 0)); print(s.getsockname()[1]); s.close()"
+        ]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let text = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard process.terminationStatus == 0,
+              let text,
+              let port = Int(text),
+              (1025...65535).contains(port) else {
+            throw NSError(domain: "VoxtralRuntimeHealthTests", code: 1)
+        }
+
+        return port
+    }
+
+    private func waitUntilReachable(url: URL, timeout: TimeInterval = 6.0) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastError: Error?
+
+        while Date() < deadline {
+            do {
+                var request = URLRequest(url: url)
+                request.timeoutInterval = 0.5
+                _ = try await URLSession.shared.data(for: request)
+                return
+            } catch {
+                lastError = error
+            }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        throw lastError ?? NSError(domain: "VoxtralRuntimeHealthTests", code: 2)
+    }
+}


### PR DESCRIPTION
## Summary
- add a managed `Mistral Voxtral (Local)` runtime with backend-specific launchers: MLX-Audio on Apple Silicon macOS and vLLM Omni on Linux GPU hosts
- keep manual Voxtral endpoint mode, with health checks that accept both `/v1/audio/voices` and OpenAPI speech-server shapes
- update settings, defaults, tests, and README so local Voxtral can run on Apple Silicon without NVIDIA

## Why
The original managed Voxtral implementation assumed `vllm`, which fails on macOS. This update adds a real Apple Silicon local path via `mlx-audio`, while preserving the Linux GPU path through `vllm-omni`.

## How to test
- run `swift test`
- run `./build.sh`
- on Apple Silicon macOS, open `Local Voxtral TTS (Managed)` and install/start the managed runtime
- on Linux GPU hosts, managed mode continues to use `vllm serve mistralai/Voxtral-4B-TTS-2603 --omni`
- leave managed mode off to verify manual endpoint mode still works against either backend

## Notes
- Apple Silicon managed mode uses the MLX model `mlx-community/Voxtral-4B-TTS-2603-mlx-bf16` via `mlx_audio.server`
- Linux managed mode keeps using `mistralai/Voxtral-4B-TTS-2603` via vLLM Omni
- this branch was validated with unit/build checks; I did not run a live MLX install in the current x86_64 shell